### PR TITLE
Disable coverage for PRs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -65,13 +65,13 @@ jobs:
           args: --all --all-features --no-fail-fast -- --nocapture
 
       - name: Generate coverage file
-        if: matrix.version == 'stable' && (github.ref == 'master' || github.event_name == 'pull_request')
+        if: matrix.version == 'stable' && github.ref == 'refs/heads/master'
         run: |
           cargo install cargo-tarpaulin
           cargo tarpaulin --out Xml --workspace --all-features
 
       - name: Upload to Codecov
-        if: matrix.version == 'stable' && (github.ref == 'master' || github.event_name == 'pull_request')
+        if: matrix.version == 'stable' && github.ref == 'refs/heads/master'
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
It's meaningless since GHA disables secrets if PR comes from forks.