### PR TITLE
Upgrade `time` to 0.2.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,9 @@
-# TODO: identity and session are waiting for time crate changes
-
 [workspace]
 members = [
   "actix-cors",
-#   "actix-identity",
+  "actix-identity",
   "actix-protobuf",
   "actix-redis",
-#   "actix-session",
+  "actix-session",
   "actix-web-httpauth",
 ]

--- a/actix-identity/CHANGES.md
+++ b/actix-identity/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased] - 2020-xx-xx
 
-* Update the `time` dependency to 0.2.5
+* Update the `time` dependency to 0.2.6
 
 ## [0.2.1] - 2020-01-10
 

--- a/actix-identity/Cargo.toml
+++ b/actix-identity/Cargo.toml
@@ -21,7 +21,7 @@ actix-service = "1.0.2"
 futures = "0.3.1"
 serde = "1.0"
 serde_json = "1.0"
-time = { version = "0.2.5", default-features = false, features = ["std"] }
+time = { version = "0.2.6", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 actix-rt = "1.0.0"

--- a/actix-identity/src/lib.rs
+++ b/actix-identity/src/lib.rs
@@ -522,7 +522,7 @@ impl CookieIdentityPolicy {
         self.max_age_time(Duration::seconds(seconds))
     }
 
-    /// Sets the `max-age` field in the session cookie being built with `chrono::Duration`.
+    /// Sets the `max-age` field in the session cookie being built with `time::Duration`.
     pub fn max_age_time(mut self, value: Duration) -> CookieIdentityPolicy {
         Rc::get_mut(&mut self.0).unwrap().max_age = Some(value);
         self

--- a/actix-redis/CHANGES.md
+++ b/actix-redis/CHANGES.md
@@ -6,6 +6,8 @@
 
 * Update `actix_web` to 2.0.0 from 2.0.0-rc
 
+* Update `time` to 0.2.6
+
 * Move repository to actix-extras
 
 ## [0.8.0] 2019-12-20

--- a/actix-redis/Cargo.toml
+++ b/actix-redis/Cargo.toml
@@ -33,7 +33,7 @@ derive_more = "0.99.2"
 futures = "0.3.1"
 redis-async = "0.6.1"
 actix-rt = "1.0.0"
-time = "0.1.42"
+time = "0.2.6"
 tokio = "0.2.6"
 tokio-util = "0.2.0"
 

--- a/actix-redis/src/session.rs
+++ b/actix-redis/src/session.rs
@@ -351,7 +351,7 @@ impl Inner {
     fn remove_cookie<B>(&self, res: &mut ServiceResponse<B>) -> Result<(), Error> {
         let mut cookie = Cookie::named(self.name.clone());
         cookie.set_value("");
-        cookie.set_max_age(Duration::seconds(0));
+        cookie.set_max_age(Duration::zero());
         cookie.set_expires(OffsetDateTime::now() - Duration::days(365));
 
         let val = HeaderValue::from_str(&cookie.to_string())

--- a/actix-redis/src/session.rs
+++ b/actix-redis/src/session.rs
@@ -13,7 +13,7 @@ use actix_web::{error, Error, HttpMessage};
 use futures::future::{ok, Future, Ready};
 use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
 use redis_async::resp::RespValue;
-use time::{self, Duration};
+use time::{self, Duration, OffsetDateTime};
 
 use crate::redis::{Command, RedisActor};
 
@@ -352,7 +352,7 @@ impl Inner {
         let mut cookie = Cookie::named(self.name.clone());
         cookie.set_value("");
         cookie.set_max_age(Duration::seconds(0));
-        cookie.set_expires(time::now() - Duration::days(365));
+        cookie.set_expires(OffsetDateTime::now() - Duration::days(365));
 
         let val = HeaderValue::from_str(&cookie.to_string())
             .map_err(error::ErrorInternalServerError)?;
@@ -632,7 +632,7 @@ mod test {
             .into_iter()
             .find(|c| c.name() == "test-session")
             .unwrap();
-        assert_ne!(time::now().tm_year, cookie_4.expires().map(|t| t.tm_year).unwrap());
+        assert_ne!(OffsetDateTime::now().year(), cookie_4.expires().map(|t| t.year()).unwrap());
 
         // Step 10: GET index, including session cookie #2 in request
         //   - set-cookie actix-session will be in response (session cookie #3)

--- a/actix-session/CHANGES.md
+++ b/actix-session/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased] - 2020-01-xx
 
-* Update the `time` dependency to 0.2.5
+* Update the `time` dependency to 0.2.6
 * [#1292](https://github.com/actix/actix-web/pull/1292) Long lasting auto-prolonged session
 
 ## [0.3.0] - 2019-12-20

--- a/actix-session/Cargo.toml
+++ b/actix-session/Cargo.toml
@@ -29,7 +29,7 @@ derive_more = "0.99.2"
 futures = "0.3.1"
 serde = "1.0"
 serde_json = "1.0"
-time = { version = "0.2.5", default-features = false, features = ["std"] }
+time = { version = "0.2.6", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 actix-rt = "1.0.0"


### PR DESCRIPTION
Before `actix-redis` or `actix-session` will compile, `actix-http` and `actix-session` need new versions published with their respective `time` upgrades. For the time being, I've added this patch within my local actix-extras/Cargo.toml file to get it to compile:

```toml
[patch.crates-io]
actix-http = { git = "https://github.com/kevinpoitra/actix-web" }
actix-session = { git = "https://github.com/kevinpoitra/actix-extras" }
```