### PR TITLE
Update actix-redis' dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-# TODO: identity and session are waiting for time crate changes
-
 [workspace]
 members = [
   "actix-cors",

--- a/actix-identity/src/lib.rs
+++ b/actix-identity/src/lib.rs
@@ -522,7 +522,7 @@ impl CookieIdentityPolicy {
         self.max_age_time(Duration::seconds(seconds))
     }
 
-    /// Sets the `max-age` field in the session cookie being built with `chrono::Duration`.
+    /// Sets the `max-age` field in the session cookie being built with `time::Duration`.
     pub fn max_age_time(mut self, value: Duration) -> CookieIdentityPolicy {
         Rc::get_mut(&mut self.0).unwrap().max_age = Some(value);
         self

--- a/actix-redis/CHANGES.md
+++ b/actix-redis/CHANGES.md
@@ -1,5 +1,15 @@
 # Changes
 
+## [Unreleased]
+
+* Update `actix` to 0.10.0-alpha.2
+
+* Update `actix-session` to 0.4.0-alpha.1
+
+* Update `actix-web` to 3.0.0-alpha.1
+
+* Update `time` to 0.2.9
+
 ## [0.8.1] 2020-02-18
 
 * Move `env_logger` dependency to dev-dependencies and update to 0.7

--- a/actix-redis/Cargo.toml
+++ b/actix-redis/Cargo.toml
@@ -21,10 +21,10 @@ path = "src/lib.rs"
 default = ["web"]
 
 # actix-web integration
-web = ["actix/http", "actix-service", "actix-web", "actix-session/cookie-session", "rand", "serde", "serde_json"]
+web = ["actix-http/actors", "actix-service", "actix-web", "actix-session/cookie-session", "rand", "serde", "serde_json"]
 
 [dependencies]
-actix = "0.9.0"
+actix = "0.10.0-alpha.2"
 actix-utils = "1.0.3"
 
 log = "0.4.6"
@@ -33,14 +33,15 @@ derive_more = "0.99.2"
 futures = "0.3.1"
 redis-async = "0.6.1"
 actix-rt = "1.0.0"
-time = "0.1.42"
+time = "0.2.9"
 tokio = "0.2.6"
 tokio-util = "0.2.0"
 
 # actix-session
-actix-web = { version = "2.0.0", optional = true }
+actix-web = { version = "3.0.0-alpha.1", optional = true }
+actix-http = { version = "2.0.0-alpha.2", optional = true }
 actix-service = { version = "1.0.0", optional = true }
-actix-session = { version = "0.3.0", optional = true }
+actix-session = { version = "0.4.0-alpha.1", optional = true }
 rand = { version = "0.7.0", optional = true }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 serde_json = { version = "1.0.40", optional = true }

--- a/actix-redis/src/session.rs
+++ b/actix-redis/src/session.rs
@@ -13,7 +13,7 @@ use actix_web::{error, Error, HttpMessage};
 use futures::future::{ok, Future, Ready};
 use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
 use redis_async::resp::RespValue;
-use time::{self, Duration};
+use time::{self, Duration, OffsetDateTime};
 
 use crate::redis::{Command, RedisActor};
 
@@ -351,8 +351,8 @@ impl Inner {
     fn remove_cookie<B>(&self, res: &mut ServiceResponse<B>) -> Result<(), Error> {
         let mut cookie = Cookie::named(self.name.clone());
         cookie.set_value("");
-        cookie.set_max_age(Duration::seconds(0));
-        cookie.set_expires(time::now() - Duration::days(365));
+        cookie.set_max_age(Duration::zero());
+        cookie.set_expires(OffsetDateTime::now() - Duration::days(365));
 
         let val = HeaderValue::from_str(&cookie.to_string())
             .map_err(error::ErrorInternalServerError)?;
@@ -632,7 +632,7 @@ mod test {
             .into_iter()
             .find(|c| c.name() == "test-session")
             .unwrap();
-        assert_ne!(time::now().tm_year, cookie_4.expires().map(|t| t.tm_year).unwrap());
+        assert_ne!(OffsetDateTime::now().year(), cookie_4.expires().map(|t| t.year()).unwrap());
 
         // Step 10: GET index, including session cookie #2 in request
         //   - set-cookie actix-session will be in response (session cookie #3)


### PR DESCRIPTION
- Included some modifications from my previous PR (#14) that were missed, such as updating `time` to 0.2 and some small documentation cleanup.
- Along with that, I bumped `actix`'s, `actix-session`'s, and `actix-web`'s versions up.