### PR TITLE
Allow for session cookies to be lazily created

### DIFF
--- a/actix-session/src/cookie.rs
+++ b/actix-session/src/cookie.rs
@@ -55,6 +55,7 @@ struct CookieSessionInner {
     name: String,
     path: String,
     domain: Option<String>,
+    lazy: bool,
     secure: bool,
     http_only: bool,
     max_age: Option<Duration>,
@@ -70,6 +71,7 @@ impl CookieSessionInner {
             name: "actix-session".to_owned(),
             path: "/".to_owned(),
             domain: None,
+            lazy: false,
             secure: true,
             http_only: true,
             max_age: None,
@@ -84,6 +86,11 @@ impl CookieSessionInner {
         state: impl Iterator<Item = (String, String)>,
     ) -> Result<(), Error> {
         let state: HashMap<String, String> = state.collect();
+
+        if self.lazy && state.is_empty() {
+            return Ok(());
+        }
+
         let value =
             serde_json::to_string(&state).map_err(CookieSessionError::Serialize)?;
         if value.len() > 4064 {
@@ -244,6 +251,12 @@ impl CookieSession {
     /// Sets the `domain` field in the session cookie being built.
     pub fn domain<S: Into<String>>(mut self, value: S) -> CookieSession {
         Rc::get_mut(&mut self.0).unwrap().domain = Some(value.into());
+        self
+    }
+
+    /// Controls if the session cookie is sent for all sessions, or only sessions with data. Default is `false`.
+    pub fn lazy(mut self, value: bool) -> CookieSession {
+        Rc::get_mut(&mut self.0).unwrap().lazy = value;
         self
     }
 
@@ -420,6 +433,37 @@ mod tests {
 
         let request = test::TestRequest::get().to_request();
         let response = app.call(request).await.unwrap();
+        assert!(response
+            .response()
+            .cookies()
+            .any(|c| c.name() == "actix-session"));
+    }
+
+    #[actix_rt::test]
+    async fn lazy_cookie() {
+        let mut app = test::init_service(
+            App::new()
+                .wrap(CookieSession::signed(&[0; 32]).secure(false).lazy(true))
+                .service(web::resource("/count").to(|ses: Session| async move {
+                    let _ = ses.set("counter", 100);
+                    "counting"
+                }))
+                .service(web::resource("/").to(|ses: Session| async move {
+                    "test"
+                })),
+        )
+        .await;
+
+        let request = test::TestRequest::get().to_request();
+        let response = app.call(request).await.unwrap();
+        assert!(response
+            .response()
+            .cookies()
+            .count() == 0);
+
+        let request = test::TestRequest::with_uri("/count").to_request();
+        let response = app.call(request).await.unwrap();
+
         assert!(response
             .response()
             .cookies()

--- a/actix-session/src/cookie.rs
+++ b/actix-session/src/cookie.rs
@@ -254,7 +254,10 @@ impl CookieSession {
         self
     }
 
-    /// Controls if the session cookie is sent for all sessions, or only sessions with data. Default is `false`.
+    /// When true, prevents adding session cookies to responses until
+    /// the session contains data. Default is `false`.
+    /// 
+    /// Useful when trying to comply with laws that require consent for setting cookies.
     pub fn lazy(mut self, value: bool) -> CookieSession {
         Rc::get_mut(&mut self.0).unwrap().lazy = value;
         self
@@ -448,7 +451,7 @@ mod tests {
                     let _ = ses.set("counter", 100);
                     "counting"
                 }))
-                .service(web::resource("/").to(|ses: Session| async move {
+                .service(web::resource("/").to(|_ses: Session| async move {
                     "test"
                 })),
         )


### PR DESCRIPTION
When laziness is enabled for the CookieSession, the cookie only gets added once the session has some data. But the current default behavior would remain unaffected unless lazy sessions are toggled on.

Behavior like this is quite useful when trying to make things compatible with cookie laws, where you might not want to store cookies until you've gained the visitor's permission to do so.

I'm really hoping for some feedback, and I'm guessing that there are better ways of doing this :)