### PR TITLE
Bugfix: AuthenticationError should set status_code

### DIFF
--- a/actix-web-httpauth/CHANGES.md
+++ b/actix-web-httpauth/CHANGES.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
   - Update the `base64` dependency to 0.12
+  - AuthenticationError's status code is preserved when converting to a ResponseError
 
 ## [0.4.1] - 2020-02-19
   - Move repository to actix-extras

--- a/actix-web-httpauth/src/extractors/errors.rs
+++ b/actix-web-httpauth/src/extractors/errors.rs
@@ -57,4 +57,26 @@ impl<C: 'static + Challenge> ResponseError for AuthenticationError<C> {
             .set(WwwAuthenticate(self.challenge.clone()))
             .finish()
     }
+
+    fn status_code(&self) -> StatusCode {
+        self.status_code
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::headers::www_authenticate::basic::Basic;
+    use actix_web::Error;
+
+    #[test]
+    fn test_status_code_is_preserved_across_error_conversions() {
+        let ae: AuthenticationError<Basic> = AuthenticationError::new(Basic::default());
+        let expected = ae.status_code;
+
+        // Converting the AuthenticationError into a ResponseError should preserve the status code.
+        let e = Error::from(ae);
+        let re = e.as_response_error();
+        assert_eq!(expected, re.status_code());
+    }
 }


### PR DESCRIPTION
I noticed that my `AuthenticationError`'s `status_code` field was 401, but when I ran `.as_response_error()` the `ResponseError`'s code was 500 (the default value). It's because impl ResponseError for AuthenticationError doesn't define the `status_code()` trait method. Merely setting the status code in `error_response` isn't enough, it seems. I added a unit test for this case too. The test will fail without my change, and pass with it.