### PR TITLE
httpauth: Remove badge metadata

### DIFF
--- a/actix-web-httpauth/Cargo.toml
+++ b/actix-web-httpauth/Cargo.toml
@@ -29,6 +29,3 @@ actix-rt = "1.0"
 [features]
 default = []
 nightly = [] # leave it for compatibility
-
-[badges]
-maintenance = { status = "passively-maintained" }


### PR DESCRIPTION
crates.io no longer displays this badge on the crate pages.