### PR TITLE
actix-cors: drop unused clippy overrides

### DIFF
--- a/actix-cors/src/lib.rs
+++ b/actix-cors/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::borrow_interior_mutable_const, clippy::type_complexity)]
 //! Cross-origin resource sharing (CORS) for Actix applications
 //!
 //! CORS middleware could be used with application and with resource.


### PR DESCRIPTION
This removes some clippy lints overrides which are not anymore
required.