### PR TITLE
httpauth: Bump up to 0.4.2

### DIFF
--- a/actix-web-httpauth/CHANGES.md
+++ b/actix-web-httpauth/CHANGES.md
@@ -9,10 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Minimum supported Rust version(MSRV) is now 1.40.0.
 
-## [unreleased]
+## [0.4.2] - 2020-07-08
   - Update the `base64` dependency to 0.12
   - AuthenticationError's status code is preserved when converting to a ResponseError
   - Minimize `futures` dependency
+  - Fix panic on `AuthenticationMiddleware` [#69]
+
+[#69]: https://github.com/actix/actix-web-httpauth/pull/69
 
 ## [0.4.1] - 2020-02-19
   - Move repository to actix-extras

--- a/actix-web-httpauth/Cargo.toml
+++ b/actix-web-httpauth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web-httpauth"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["svartalf <self@svartalf.info>", "Yuki Okushi <huyuumi.dev@gmail.com>"]
 description = "HTTP authentication schemes for actix-web"
 readme = "README.md"

--- a/actix-web-httpauth/README.md
+++ b/actix-web-httpauth/README.md
@@ -2,7 +2,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/actix-web-httpauth)](https://crates.io/crates/actix-web-httpauth)
 [![Documentation](https://docs.rs/actix-web-httpauth/badge.svg)](https://docs.rs/actix-web-httpauth)
-[![Dependency Status](https://deps.rs/crate/actix-web-httpauth/0.4.1/status.svg)](https://deps.rs/crate/actix-web-httpauth/0.4.1)
+[![Dependency Status](https://deps.rs/crate/actix-web-httpauth/0.4.2/status.svg)](https://deps.rs/crate/actix-web-httpauth/0.4.2)
 ![Apache 2.0 or MIT licensed](https://img.shields.io/crates/l/actix-web-httpauth)
 [![Join the chat at https://gitter.im/actix/actix](https://badges.gitter.im/actix/actix.svg)](https://gitter.im/actix/actix?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 


### PR DESCRIPTION
I think it's worth to go with 0.4.2 before making alpha release.