### PR TITLE
Replace deprecated `from_master` with `derive_from`

### DIFF
--- a/actix-identity/src/lib.rs
+++ b/actix-identity/src/lib.rs
@@ -341,8 +341,8 @@ impl CookieIdentityInner {
     fn new(key: &[u8]) -> CookieIdentityInner {
         let key_v2: Vec<u8> = key.iter().chain([1, 0, 0, 0].iter()).cloned().collect();
         CookieIdentityInner {
-            key: Key::from_master(key),
-            key_v2: Key::from_master(&key_v2),
+            key: Key::derive_from(key),
+            key_v2: Key::derive_from(&key_v2),
             name: "actix-identity".to_owned(),
             path: "/".to_owned(),
             domain: None,
@@ -765,7 +765,7 @@ mod tests {
 
     fn legacy_login_cookie(identity: &'static str) -> Cookie<'static> {
         let mut jar = CookieJar::new();
-        jar.private(&Key::from_master(&COOKIE_KEY_MASTER))
+        jar.private(&Key::derive_from(&COOKIE_KEY_MASTER))
             .add(Cookie::new(COOKIE_NAME, identity));
         jar.get(COOKIE_NAME).unwrap().clone()
     }
@@ -781,7 +781,7 @@ mod tests {
             .chain([1, 0, 0, 0].iter())
             .copied()
             .collect();
-        jar.private(&Key::from_master(&key)).add(Cookie::new(
+        jar.private(&Key::derive_from(&key)).add(Cookie::new(
             COOKIE_NAME,
             serde_json::to_string(&CookieValue {
                 identity: identity.to_string(),
@@ -805,7 +805,7 @@ mod tests {
             cookies.add(Cookie::parse(cookie.to_str().unwrap().to_string()).unwrap());
         }
         let cookie = cookies
-            .private(&Key::from_master(&COOKIE_KEY_MASTER))
+            .private(&Key::derive_from(&COOKIE_KEY_MASTER))
             .get(COOKIE_NAME)
             .unwrap();
         assert_eq!(cookie.value(), identity);
@@ -840,7 +840,7 @@ mod tests {
             .copied()
             .collect();
         let cookie = cookies
-            .private(&Key::from_master(&key))
+            .private(&Key::derive_from(&key))
             .get(COOKIE_NAME)
             .unwrap();
         let cv: CookieValue = serde_json::from_str(cookie.value()).unwrap();

--- a/actix-redis/src/session.rs
+++ b/actix-redis/src/session.rs
@@ -32,7 +32,7 @@ impl RedisSession {
     /// * `addr` - address of the redis server
     pub fn new<S: Into<String>>(addr: S, key: &[u8]) -> RedisSession {
         RedisSession(Rc::new(Inner {
-            key: Key::from_master(key),
+            key: Key::derive_from(key),
             cache_keygen: Box::new(|key: &str| format!("session:{}", &key)),
             ttl: "7200".to_owned(),
             addr: RedisActor::start(addr),

--- a/actix-session/src/cookie.rs
+++ b/actix-session/src/cookie.rs
@@ -67,7 +67,7 @@ impl CookieSessionInner {
     fn new(key: &[u8], security: CookieSecurity) -> CookieSessionInner {
         CookieSessionInner {
             security,
-            key: Key::from_master(key),
+            key: Key::derive_from(key),
             name: "actix-session".to_owned(),
             path: "/".to_owned(),
             domain: None,


### PR DESCRIPTION
See: https://docs.rs/cookie/0.14.1/cookie/struct.Key.html#method.from_master