### PR TITLE
lint and readme cleanup

### DIFF
--- a/actix-cors/CHANGES.md
+++ b/actix-cors/CHANGES.md
@@ -5,7 +5,7 @@
 
 ## 0.3.0 - 2020-09-11
 * Update `actix-web` dependency to 3.0.0.
-* Minimum supported Rust version(MSRV) is now 1.42.0.
+* Minimum supported Rust version (MSRV) is now 1.42.0.
 * Implement the Debug trait on all public types.
 
 

--- a/actix-cors/src/lib.rs
+++ b/actix-cors/src/lib.rs
@@ -590,7 +590,7 @@ impl Inner {
                     AllOrSome::Some(ref allowed_origins) => allowed_origins
                         .get(origin)
                         .map(|_| ())
-                        .ok_or_else(|| CorsError::OriginNotAllowed),
+                        .ok_or(CorsError::OriginNotAllowed),
                 };
             }
             Err(CorsError::BadOrigin)
@@ -638,7 +638,7 @@ impl Inner {
                         .methods
                         .get(&method)
                         .map(|_| ())
-                        .ok_or_else(|| CorsError::MethodNotAllowed);
+                        .ok_or(CorsError::MethodNotAllowed);
                 }
             }
             Err(CorsError::BadRequestMethod)
@@ -1072,6 +1072,7 @@ mod tests {
                 .collect::<Vec<&str>>();
 
             for h in exposed_headers {
+                #[allow(clippy::needless_collect)]
                 assert!(headers.contains(&h.as_str()));
             }
         }

--- a/actix-protobuf/CHANGES.md
+++ b/actix-protobuf/CHANGES.md
@@ -5,7 +5,7 @@
 
 ## 0.6.0 - 2020-09-11
 * Update `actix-web` dependency to 3.0.0.
-* Minimum supported Rust version(MSRV) is now 1.42.0 to use `matches!` macro.
+* Minimum supported Rust version (MSRV) is now 1.42.0 to use `matches!` macro.
 
 
 ## 0.6.0-alpha.1 - 2020-07-06

--- a/actix-protobuf/examples/prost-example/Cargo.toml
+++ b/actix-protobuf/examples/prost-example/Cargo.toml
@@ -2,15 +2,16 @@
 name = "prost-example"
 version = "0.5.1"
 edition = "2018"
-authors = ["kingxsp <jin.hb.zh@outlook.com>", "Yuki Okushi <huyuumi.dev@gmail.com>"]
+authors = [
+    "kingxsp <jin.hb.zh@outlook.com>",
+    "Yuki Okushi <huyuumi.dev@gmail.com>"
+]
 
 [dependencies]
 actix-web = "3.0.0"
-actix-rt = "1"
 actix-protobuf = { path = "../../" }
 
 bytes = "0.5"
-env_logger = "*"
-
+env_logger = "0.7"
 prost = "0.6.0"
 prost-derive = "0.6.0"

--- a/actix-protobuf/examples/prost-example/src/main.rs
+++ b/actix-protobuf/examples/prost-example/src/main.rs
@@ -1,13 +1,12 @@
-#[macro_use]
-extern crate prost_derive;
-
 use actix_protobuf::*;
 use actix_web::*;
+use prost_derive::Message;
 
 #[derive(Clone, PartialEq, Message)]
 pub struct MyObj {
     #[prost(int32, tag = "1")]
     pub number: i32,
+
     #[prost(string, tag = "2")]
     pub name: String,
 }
@@ -17,7 +16,7 @@ async fn index(msg: ProtoBuf<MyObj>) -> Result<HttpResponse> {
     HttpResponse::Ok().protobuf(msg.0) // <- send response
 }
 
-#[actix_rt::main]
+#[actix_web::main]
 async fn main() -> std::io::Result<()> {
     std::env::set_var("RUST_LOG", "actix_web=debug,actix_server=info");
     env_logger::init();

--- a/actix-protobuf/src/lib.rs
+++ b/actix-protobuf/src/lib.rs
@@ -241,7 +241,7 @@ impl<T: Message + Default + 'static> Future for ProtoBufMessage<T> {
                     }
                 }
 
-                return Ok(<T>::decode(&mut body)?);
+                Ok(<T>::decode(&mut body)?)
             }
             .boxed_local(),
         );

--- a/actix-redis/CHANGES.md
+++ b/actix-redis/CHANGES.md
@@ -24,39 +24,32 @@
 * Update `time` to 0.2.9
 
 
-## [0.8.1] 2020-02-18
-
+## 0.8.1 - 2020-02-18
 * Move `env_logger` dependency to dev-dependencies and update to 0.7
-
 * Update `actix_web` to 2.0.0 from 2.0.0-rc
-
 * Move repository to actix-extras
 
-## [0.8.0] 2019-12-20
 
+## 0.8.0 - 2019-12-20
 * Release
 
-## [0.8.0-alpha.1] 2019-12-16
 
+## 0.8.0-alpha.1 - 2019-12-16
 * Migrate to actix 0.9
 
-## 0.7 (2019-09-25)
 
+## 0.7.0 - 2019-09-25
 * added cache_keygen functionality to RedisSession builder, enabling support for
   customizable cache key creation
 
 
-## 0.6.1 (2019-07-19)
-
+## 0.6.1 - 2019-07-19
 * remove ClonableService usage
-
 * added comprehensive tests for session workflow
 
 
-## 0.6.0 (2019-07-08)
-
+## 0.6.0 - 2019-07-08
 * actix-web 1.0.0 compatibility
-
 * Upgraded logic that evaluates session state, including new SessionStatus field,
   and introduced ``session.renew()`` and ``session.purge()`` functionality.
   Use ``renew()`` to cycle the session key at successful login.  ``renew()`` keeps a
@@ -65,33 +58,27 @@
   session's redis cache entry.
 
 
-
-## 0.5.1 (2018-08-02)
-
+## 0.5.1 - 2018-08-02
 * Use cookie 0.11
 
 
-## 0.5.0 (2018-07-21)
-
+## 0.5.0 - 2018-07-21
 * Session cookie configuration
-
 * Actix/Actix-web 0.7 compatibility
 
 
-## 0.4.0 (2018-05-08)
-
+## 0.4.0 - 2018-05-08
 * Actix web 0.6 compatibility
 
-## 0.3.0 (2018-04-10)
 
+## 0.3.0 - 2018-04-10
 * Actix web 0.5 compatibility
 
-## 0.2.0 (2018-02-28)
 
+## 0.2.0 - 2018-02-28
 * Use resolver actor from actix
-
 * Use actix web 0.5
 
-## 0.1.0 (2018-01-23)
 
+## 0.1.0 - 2018-01-23
 * First release

--- a/actix-session/CHANGES.md
+++ b/actix-session/CHANGES.md
@@ -5,7 +5,7 @@
 
 ## 0.4.0 - 2020-09-11
 * Update `actix-web` dependency to 3.0.0.
-* Minimum supported Rust version(MSRV) is now 1.42.0.
+* Minimum supported Rust version (MSRV) is now 1.42.0.
 
 
 ## 0.4.0-alpha.1 - 2020-03-14

--- a/actix-web-httpauth/CHANGES.md
+++ b/actix-web-httpauth/CHANGES.md
@@ -5,59 +5,53 @@
 
 ## 0.5.0 - 2020-09-11
 * Update `actix-web` dependency to 3.0.0.
-* Minimum supported Rust version(MSRV) is now 1.42.0.
+* Minimum supported Rust version (MSRV) is now 1.42.0.
 
 
-## [0.4.2] - 2020-07-08
-  - Update the `base64` dependency to 0.12
-  - AuthenticationError's status code is preserved when converting to a ResponseError
-  - Minimize `futures` dependency
-  - Fix panic on `AuthenticationMiddleware` [#69]
+## 0.4.2 - 2020-07-08
+- Update the `base64` dependency to 0.12
+- AuthenticationError's status code is preserved when converting to a ResponseError
+- Minimize `futures` dependency
+- Fix panic on `AuthenticationMiddleware` [#69]
 
 [#69]: https://github.com/actix/actix-web-httpauth/pull/69
 
-## [0.4.1] - 2020-02-19
-  - Move repository to actix-extras
 
-## [0.4.0] - 2020-01-14
+## 0.4.1 - 2020-02-19
+- Move repository to actix-extras
 
-### Changed
-  - Depends on `actix-web = "^2.0"`, `actix-service = "^1.0"`, and `futures = "^0.3"` version now ([#14])
-  - Depends on `bytes = "^0.5"` and `base64 = "^0.11"` now
+
+## 0.4.0 - 2020-01-14
+- Depends on `actix-web = "^2.0"`, `actix-service = "^1.0"`, and `futures = "^0.3"` version now ([#14])
+- Depends on `bytes = "^0.5"` and `base64 = "^0.11"` now
 
 [#14]: https://github.com/actix/actix-web-httpauth/pull/14
 
-## [0.3.2] - 2019-07-19
 
-### Changed
-  - Middleware accepts any `Fn` as a validator function instead of `FnMut` ([#11](https://github.com/actix/actix-web-httpauth/pull/11))
+## 0.3.2 - 2019-07-19
+- Middleware accepts any `Fn` as a validator function instead of `FnMut` ([#11](https://github.com/actix/actix-web-httpauth/pull/11))
 
-## [0.3.1] - 2019-06-09
 
-### Fixed
-  - Multiple calls to the middleware would result in panic
+## 0.3.1 - 2019-06-09
+- Multiple calls to the middleware would result in panic
 
-## [0.3.0] - 2019-06-05
 
-### Changed
-  - Crate edition was changed to `2018`, same as `actix-web`
-  - Depends on `actix-web = "^1.0"` version now
-  - `WWWAuthenticate` header struct was renamed into `WwwAuthenticate`
-  - Challenges and extractor configs are now operating with `Cow<'static, str>` types instead of `String` types
+## 0.3.0 - 2019-06-05
+- Crate edition was changed to `2018`, same as `actix-web`
+- Depends on `actix-web = "^1.0"` version now
+- `WWWAuthenticate` header struct was renamed into `WwwAuthenticate`
+- Challenges and extractor configs are now operating with `Cow<'static, str>` types instead of `String` types
 
-## [0.2.0] - 2019-04-26
 
-### Changed
-  - `actix-web` dependency is used without default features now ([#6](https://github.com/actix/actix-web-httpauth/pull/6))
-  - `base64` dependency version was bumped to `0.10`
+## 0.2.0 - 2019-04-26
+- `actix-web` dependency is used without default features now ([#6](https://github.com/actix/actix-web-httpauth/pull/6))
+- `base64` dependency version was bumped to `0.10`
 
-## [0.1.0] - 2018-09-08
 
-### Changed
-  - Update to `actix-web = "0.7"` version
+## 0.1.0 - 2018-09-08
+- Update to `actix-web = "0.7"` version
 
-## [0.0.4] - 2018-07-01
 
-### Fixed
-  - Fix possible panic at `IntoHeaderValue` implementation for `headers::authorization::Basic`
-  - Fix possible panic at `headers::www_authenticate::challenge::bearer::Bearer::to_bytes` call
+## 0.0.4 - 2018-07-01
+- Fix possible panic at `IntoHeaderValue` implementation for `headers::authorization::Basic`
+- Fix possible panic at `headers::www_authenticate::challenge::bearer::Bearer::to_bytes` call


### PR DESCRIPTION
## PR Type
Docs + Lint

## PR Checklist
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
- Addresses clippy warnings.
- Makes unrendered readme formatting much more clear without changing rendered output.