### PR TITLE
enforce required minimum redis-async patch version

### DIFF
--- a/actix-redis/CHANGES.md
+++ b/actix-redis/CHANGES.md
@@ -1,6 +1,7 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
+* Enforce minimum redis-async version of 0.6.3 to workaround breaking patch change.
 
 
 ## 0.9.0 - 2020-09-11

--- a/actix-redis/Cargo.toml
+++ b/actix-redis/Cargo.toml
@@ -39,7 +39,7 @@ log = "0.4.6"
 backoff = "0.2.1"
 derive_more = "0.99.2"
 futures-util = { version = "0.3.5", default-features = false }
-redis-async = "0.6.1"
+redis-async = "0.6.3"
 actix-rt = "1.1.1"
 time = "0.2.9"
 tokio = "0.2.6"


### PR DESCRIPTION
## PR Type
Fix

## PR Checklist
- [x] A changelog entry has been made for the appropriate packages.


## Overview
Enforce minimum required patch version for redis-async crate to avoid confusing errors about actix-redis not compiling (re-discovered while updating examples repo).