### PR TITLE
add CookieIdentityPolicy::http_only method

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -68,13 +68,13 @@ jobs:
           args: --all --all-features --no-fail-fast -- --nocapture
 
       - name: Generate coverage file
-        if: matrix.version == 'stable' && (github.ref == 'master' || github.event_name == 'pull_request')
+        if: matrix.version == 'stable' && (github.ref == 'refs/heads/master' || github.event_name == 'pull_request')
         run: |
           cargo install cargo-tarpaulin --vers "^0.13"
           cargo tarpaulin --out Xml --workspace --all-features
 
       - name: Upload to Codecov
-        if: matrix.version == 'stable' && (github.ref == 'master' || github.event_name == 'pull_request')
+        if: matrix.version == 'stable' && (github.ref == 'refs/heads/master' || github.event_name == 'pull_request')
         uses: codecov/codecov-action@v1
         with:
           file: cobertura.xml

--- a/actix-identity/CHANGES.md
+++ b/actix-identity/CHANGES.md
@@ -1,7 +1,7 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
-* Add method to set HttpOnly flag on cookie identity.
+* Add method to set HttpOnly flag on cookie identity. [#102]
 
 
 ## 0.3.0 - 2020-09-11
@@ -25,3 +25,8 @@
 
 ## 0.1.0 - 2019-06-xx
 * Move identity middleware to separate crate
+
+
+<!-- PR Links -->
+
+[#102]: https://github.com/actix/actix-extras/pull/102

--- a/actix-identity/CHANGES.md
+++ b/actix-identity/CHANGES.md
@@ -1,6 +1,7 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
+* Add method to set HttpOnly flag on cookie identity.
 
 
 ## 0.3.0 - 2020-09-11


### PR DESCRIPTION
## PR Type
Feature

## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
Adds method for setting HttpOnly flag on cookies from `CookieIdentityPolicy`.

Closes #101
