### PR TITLE
Update Session::set_session to take IntoIterator

### DIFF
--- a/actix-redis/src/session.rs
+++ b/actix-redis/src/session.rs
@@ -156,7 +156,7 @@ where
         Box::pin(async move {
             let state = inner.load(&req).await?;
             let value = if let Some((state, value)) = state {
-                Session::set_session(state.into_iter(), &mut req);
+                Session::set_session(state, &mut req);
                 Some(value)
             } else {
                 None

--- a/actix-session/CHANGES.md
+++ b/actix-session/CHANGES.md
@@ -1,6 +1,7 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
+* `Session::set_session` takes a `IntoIterator` instead of `Iterator`
 
 
 ## 0.4.0 - 2020-09-11

--- a/actix-session/src/cookie.rs
+++ b/actix-session/src/cookie.rs
@@ -356,7 +356,7 @@ where
         let inner = self.inner.clone();
         let (is_new, state) = self.inner.load(&req);
         let prolong_expiration = self.inner.expires_in.is_some();
-        Session::set_session(state.into_iter(), &mut req);
+        Session::set_session(state, &mut req);
 
         let fut = self.service.call(req);
 

--- a/actix-session/src/lib.rs
+++ b/actix-session/src/lib.rs
@@ -197,12 +197,12 @@ impl Session {
     /// let mut req = test::TestRequest::default().to_srv_request();
     ///
     /// Session::set_session(
-    ///     vec![("counter".to_string(), serde_json::to_string(&0).unwrap())].into_iter(),
+    ///     vec![("counter".to_string(), serde_json::to_string(&0).unwrap())],
     ///     &mut req,
     /// );
     /// ```
     pub fn set_session(
-        data: impl Iterator<Item = (String, String)>,
+        data: impl IntoIterator<Item = (String, String)>,
         req: &mut ServiceRequest,
     ) {
         let session = Session::get_session(&mut *req.extensions_mut());
@@ -279,8 +279,7 @@ mod tests {
         let mut req = test::TestRequest::default().to_srv_request();
 
         Session::set_session(
-            vec![("key".to_string(), serde_json::to_string("value").unwrap())]
-                .into_iter(),
+            vec![("key".to_string(), serde_json::to_string("value").unwrap())],
             &mut req,
         );
         let session = Session::get_session(&mut *req.extensions_mut());
@@ -301,7 +300,7 @@ mod tests {
         let mut req = test::TestRequest::default().to_srv_request();
 
         Session::set_session(
-            vec![("key".to_string(), serde_json::to_string(&true).unwrap())].into_iter(),
+            vec![("key".to_string(), serde_json::to_string(&true).unwrap())],
             &mut req,
         );
 
@@ -315,7 +314,7 @@ mod tests {
         let mut req = test::TestRequest::default().to_srv_request();
 
         Session::set_session(
-            vec![("key".to_string(), serde_json::to_string(&10).unwrap())].into_iter(),
+            vec![("key".to_string(), serde_json::to_string(&10).unwrap())],
             &mut req,
         );
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
This changes nothing about the body of the method, since it just passes the received iterator into `.extend()`, which itself takes `IntoIterator`.
However, it allows omitting `.into_iter()` calls in many places by just passing the collections directly, while staying fully backwards-compatible due to the standard library's blanket `impl<I: Iterator> IntoIterator for I`.

It is primarily a QoL change for people writing their own session backends.


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->