### PR TITLE
Disable macOS cache to fix spurious failures

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,7 +27,7 @@ jobs:
         options: --entrypoint redis-server
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
 
       - name: Install ${{ matrix.version }}
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
 
       - name: Install ${{ matrix.version }}
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -29,24 +29,6 @@ jobs:
           profile: minimal
           override: true
 
-      - name: Generate Cargo.lock
-        uses: actions-rs/cargo@v1
-        with:
-          command: generate-lockfile
-      - name: Cache cargo dirs
-        uses: actions/cache@v2
-        with:
-          path:
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/bin
-          key: ${{ matrix.version }}-x86_64-apple-darwin-gnu-cargo-trimmed-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo build
-        uses: actions/cache@v2
-        with:
-          path: target
-          key: ${{ matrix.version }}-x86_64-apple-darwin-cargo-build-trimmed-${{ hashFiles('**/Cargo.lock') }}
-
       - name: check build
         uses: actions-rs/cargo@v1
         with:
@@ -62,8 +44,3 @@ jobs:
                 --package=actix-protobuf
                 --package=actix-web-httpauth
                 --all-features --no-fail-fast -- --nocapture
-
-      - name: Clear the cargo caches
-        run: |
-          cargo install cargo-cache --no-default-features --features ci-autoclean
-          cargo-cache

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -26,7 +26,7 @@ jobs:
         options: --entrypoint redis-server
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
 
       - name: Install ${{ matrix.version }}
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/upload-doc.yml
+++ b/.github/workflows/upload-doc.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.repository == 'actix/actix-extras'
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
 
       - name: Install ${{ matrix.version }}
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
## Overview

We've experienced the spurious failures on macOS, e.g. https://github.com/actix/actix-extras/runs/1225358101?check_suite_focus=true (you can find some more in https://github.com/actix/actix-extras/actions?query=is%3Afailure).
I think the cause is https://github.com/actions-rs/cargo/issues/111 and seems the cache for it is related. Let's disable it for now and see what happens.