### PR TITLE
cors: hide service struct from docs

### DIFF
--- a/actix-cors/CHANGES.md
+++ b/actix-cors/CHANGES.md
@@ -2,8 +2,10 @@
 
 ## Unreleased - 2020-xx-xx
 * Disallow `*` in `Cors::allowed_origin` by panicking. [#114].
+* Hide `CorsMiddleware` from rustdocs. [#118].
 
 [#114]: https://github.com/actix/actix-extras/pull/114
+[#118]: https://github.com/actix/actix-extras/pull/118
 
 
 ## 0.4.1 - 2020-10-07

--- a/actix-cors/src/middleware.rs
+++ b/actix-cors/src/middleware.rs
@@ -21,6 +21,7 @@ use crate::Inner;
 ///
 /// This struct contains the settings for CORS requests to be validated and for responses to
 /// be generated.
+#[doc(hidden)]
 #[derive(Debug, Clone)]
 pub struct CorsMiddleware<S> {
     pub(crate) service: S,


### PR DESCRIPTION
This hides `CorsMiddleware` from rustdocs, following the pattern of
the rest of `actix_web::middleware` implementations.
