### PR TITLE
CORS builder rework

### DIFF
--- a/actix-cors/CHANGES.md
+++ b/actix-cors/CHANGES.md
@@ -2,10 +2,18 @@
 
 ## Unreleased - 2020-xx-xx
 * Disallow `*` in `Cors::allowed_origin` by panicking. [#114].
-* Hide `CorsMiddleware` from rustdocs. [#118].
+* Hide `CorsMiddleware` from docs. [#118].
+* `CorsFactory` is removed. [#119]
+* The `impl Default` constructor is now overly-restrictive. [#119]
+* Added `Cors::permissive()` constructor that allows anything. [#119]
+* Adds methods for each property to reset to a permissive state. (`allow_any_origin`, `expose_any_header`, etc.) [#119]
+* Errors are now propagated with `Transform::InitError` instead of panicking. [#119]
+* Fixes bug where allowed origin functions are not called if `allowed_origins` is All. [#119]
+* `AllOrSome` is no longer public. [#119]
 
 [#114]: https://github.com/actix/actix-extras/pull/114
 [#118]: https://github.com/actix/actix-extras/pull/118
+[#119]: https://github.com/actix/actix-extras/pull/119
 
 
 ## 0.4.1 - 2020-10-07

--- a/actix-cors/Cargo.toml
+++ b/actix-cors/Cargo.toml
@@ -23,6 +23,7 @@ actix-web = { version = "3.0.0", default-features = false }
 derive_more = "0.99.2"
 futures-util = { version = "0.3.4", default-features = false }
 log = "0.4"
+once_cell = "1"
 tinyvec = "1.0.0"
 
 [dev-dependencies]

--- a/actix-cors/Cargo.toml
+++ b/actix-cors/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "actix-cors"
 version = "0.4.1"
-authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
+authors = [
+    "Nikolay Kim <fafhrd91@gmail.com>",
+    "Rob Ede <robjtede@icloud.com>"
+]
 description = "Cross-Origin Resource Sharing (CORS) controls for Actix Web"
 readme = "README.md"
 keywords = ["actix", "cors", "web", "security", "crossorigin"]
@@ -19,8 +22,11 @@ path = "src/lib.rs"
 actix-web = { version = "3.0.0", default-features = false }
 derive_more = "0.99.2"
 futures-util = { version = "0.3.4", default-features = false }
+log = "0.4"
+tinyvec = "1.0.0"
 
 [dev-dependencies]
-actix-service = "1.0.6"
-actix-rt = "1.1.1"
-regex = "1.3.9"
+actix-service = "1"
+actix-rt = "1"
+pretty_env_logger = "0.4"
+regex = "1.4"

--- a/actix-cors/examples/cors.rs
+++ b/actix-cors/examples/cors.rs
@@ -1,0 +1,46 @@
+use actix_cors::Cors;
+use actix_web::{http::header, web, App, HttpServer};
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    HttpServer::new(move || {
+        App::new()
+            .wrap(
+                Cors::new()
+                    // add specific origin to allowed origin list
+                    // .allowed_origin("http://project.local:8080")
+                    // allow any port on localhost
+                    // .allowed_origin_fn(|origin_hdr, _req_head| {
+                    .allowed_origin_fn(|req_head| {
+                        // origin_hdr.as_bytes().starts_with(b"http://localhost")
+
+                        // a manual alternative
+                        // unwrapping is acceptable on the origin header since this function is
+                        // only called when it exists
+
+                        req_head
+                            .headers()
+                            .get(header::ORIGIN)
+                            .unwrap()
+                            .as_bytes()
+                            .starts_with(b"http://localhost")
+                    })
+                    // set allowed methods list
+                    .allowed_methods(vec!["GET", "POST"])
+                    // set allowed request header list
+                    .allowed_headers(&[header::AUTHORIZATION, header::ACCEPT])
+                    // add header to allowed list
+                    .allowed_header(header::CONTENT_TYPE)
+                    // set list of headers that are safe to expose
+                    .expose_headers(&[header::CONTENT_DISPOSITION])
+                    // set CORS rules ttl
+                    .max_age(3600)
+                    // build CORS middleware
+                    .finish(),
+            )
+            .default_service(web::to(|| async { "Hello world!" }))
+    })
+    .bind("127.0.0.1:8080")?
+    .run()
+    .await
+}

--- a/actix-cors/examples/cors.rs
+++ b/actix-cors/examples/cors.rs
@@ -8,6 +8,8 @@ async fn main() -> std::io::Result<()> {
     HttpServer::new(move || {
         App::new()
             .wrap(
+                // default settings are overly restrictive to reduce chance of
+                // misconfiguration leading to security concerns
                 Cors::default()
                     // add specific origin to allowed origin list
                     .allowed_origin("http://project.local:8080")

--- a/actix-cors/examples/cors.rs
+++ b/actix-cors/examples/cors.rs
@@ -3,21 +3,18 @@ use actix_web::{http::header, web, App, HttpServer};
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+    pretty_env_logger::init();
+
     HttpServer::new(move || {
         App::new()
             .wrap(
-                Cors::new()
+                Cors::default()
                     // add specific origin to allowed origin list
-                    // .allowed_origin("http://project.local:8080")
+                    .allowed_origin("http://project.local:8080")
                     // allow any port on localhost
-                    // .allowed_origin_fn(|origin_hdr, _req_head| {
                     .allowed_origin_fn(|req_head| {
-                        // origin_hdr.as_bytes().starts_with(b"http://localhost")
-
-                        // a manual alternative
                         // unwrapping is acceptable on the origin header since this function is
                         // only called when it exists
-
                         req_head
                             .headers()
                             .get(header::ORIGIN)
@@ -34,9 +31,7 @@ async fn main() -> std::io::Result<()> {
                     // set list of headers that are safe to expose
                     .expose_headers(&[header::CONTENT_DISPOSITION])
                     // set CORS rules ttl
-                    .max_age(3600)
-                    // build CORS middleware
-                    .finish(),
+                    .max_age(3600),
             )
             .default_service(web::to(|| async { "Hello world!" }))
     })

--- a/actix-cors/src/all_or_some.rs
+++ b/actix-cors/src/all_or_some.rs
@@ -26,11 +26,19 @@ impl<T> AllOrSome<T> {
         !self.is_all()
     }
 
-    /// Returns &T.
+    /// Provides a shared reference to `T` if variant is `Some`.
     pub fn as_ref(&self) -> Option<&T> {
         match *self {
             AllOrSome::All => None,
             AllOrSome::Some(ref t) => Some(t),
+        }
+    }
+
+    /// Provides a mutable reference to `T` if variant is `Some`.
+    pub fn as_mut(&mut self) -> Option<&mut T> {
+        match *self {
+            AllOrSome::All => None,
+            AllOrSome::Some(ref mut t) => Some(t),
         }
     }
 }

--- a/actix-cors/src/all_or_some.rs
+++ b/actix-cors/src/all_or_some.rs
@@ -1,5 +1,5 @@
 /// An enum signifying that some of type `T` is allowed, or `All` (anything is allowed).
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AllOrSome<T> {
     /// Everything is allowed. Usually equivalent to the `*` value.
     All,

--- a/actix-cors/src/all_or_some.rs
+++ b/actix-cors/src/all_or_some.rs
@@ -22,6 +22,7 @@ impl<T> AllOrSome<T> {
     }
 
     /// Returns whether this is a `Some` variant.
+    #[allow(dead_code)]
     pub fn is_some(&self) -> bool {
         !self.is_all()
     }

--- a/actix-cors/src/builder.rs
+++ b/actix-cors/src/builder.rs
@@ -32,7 +32,7 @@ pub(crate) fn cors<'a>(
 /// # Example
 ///
 /// ```rust
-/// use actix_cors::{Cors, CorsFactory};
+/// use actix_cors::Cors;
 /// use actix_web::http::header;
 ///
 /// let cors = Cors::default()
@@ -80,6 +80,17 @@ impl Cors {
             inner: Rc::new(inner),
             error: None,
         }
+    }
+
+    /// Resets allowed origin list to a state where any origin is accepted.
+    ///
+    /// See [`Cors::allowed_origin`] for more info on allowed origins.
+    pub fn allow_any_origin(mut self) -> Cors {
+        if let Some(cors) = cors(&mut self.inner, &self.error) {
+            cors.allowed_origins = AllOrSome::All;
+        }
+
+        self
     }
 
     /// Add an origin that is allowed to make requests.
@@ -491,7 +502,7 @@ mod test {
             .to_srv_request();
 
         let resp = test::call_service(&mut cors, req).await;
-        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
     #[actix_rt::test]

--- a/actix-cors/src/error.rs
+++ b/actix-cors/src/error.rs
@@ -6,17 +6,13 @@ use derive_more::{Display, Error};
 #[derive(Debug, Clone, Display, Error)]
 #[non_exhaustive]
 pub enum CorsError {
-    /// Allowed origin parameter must not be wildcard (`*`).
-    #[display(fmt = "Allowed origin parameter must not be wildcard (`*`).")]
+    /// Allowed origin argument must not be wildcard (`*`).
+    #[display(fmt = "`allowed_origin` argument must not be wildcard (`*`).")]
     WildcardOrigin,
 
     /// Request header `Origin` is required but was not provided.
     #[display(fmt = "Request header `Origin` is required but was not provided.")]
     MissingOrigin,
-
-    /// Request header `Origin` could not be parsed correctly.
-    #[display(fmt = "Request header `Origin` could not be parsed correctly.")]
-    BadOrigin,
 
     /// Request header `Access-Control-Request-Method` is required but is missing.
     #[display(

--- a/actix-cors/src/error.rs
+++ b/actix-cors/src/error.rs
@@ -4,7 +4,12 @@ use derive_more::{Display, Error};
 
 /// Errors that can occur when processing CORS guarded requests.
 #[derive(Debug, Clone, Display, Error)]
+#[non_exhaustive]
 pub enum CorsError {
+    /// Allowed origin parameter must not be wildcard (`*`).
+    #[display(fmt = "Allowed origin parameter must not be wildcard (`*`).")]
+    WildcardOrigin,
+
     /// Request header `Origin` is required but was not provided.
     #[display(fmt = "Request header `Origin` is required but was not provided.")]
     MissingOrigin,

--- a/actix-cors/src/inner.rs
+++ b/actix-cors/src/inner.rs
@@ -61,11 +61,12 @@ pub(crate) struct Inner {
     pub(crate) vary_header: bool,
 }
 
-static EMPTY_ORIGIN_SET: Lazy<HashSet<HeaderValue>> = Lazy::new(|| HashSet::new());
+static EMPTY_ORIGIN_SET: Lazy<HashSet<HeaderValue>> = Lazy::new(HashSet::new);
 
 impl Inner {
     pub(crate) fn validate_origin(&self, req: &RequestHead) -> Result<(), CorsError> {
         // return early if all origins are allowed or get ref to allowed origins set
+        #[allow(clippy::mutable_key_type)]
         let allowed_origins = match &self.allowed_origins {
             AllOrSome::All if self.allowed_origins_fns.is_empty() => return Ok(()),
             AllOrSome::Some(allowed_origins) => allowed_origins,

--- a/actix-cors/src/lib.rs
+++ b/actix-cors/src/lib.rs
@@ -1,15 +1,12 @@
 //! Cross-Origin Resource Sharing (CORS) controls for Actix Web.
 //!
-//! This middleware can be applied to both applications and resources. Once built,
-//! [`CorsFactory`] can be used as a parameter for actix-web `App::wrap()`,
+//! This middleware can be applied to both applications and resources. Once built, a
+//! [`Cors`] builder can be used as an argument for Actix Web's `App::wrap()`,
 //! `Scope::wrap()`, or `Resource::wrap()` methods.
 //!
 //! This CORS middleware automatically handles `OPTIONS` preflight requests.
 //!
 //! # Example
-//!
-//! In this example a custom CORS middleware is registered for the "/index.html" endpoint.
-//!
 //! ```rust,no_run
 //! use actix_cors::Cors;
 //! use actix_web::{get, http, web, App, HttpRequest, HttpResponse, HttpServer};

--- a/actix-cors/src/lib.rs
+++ b/actix-cors/src/lib.rs
@@ -64,5 +64,5 @@ mod middleware;
 pub use all_or_some::AllOrSome;
 pub use builder::{Cors, CorsFactory};
 pub use error::CorsError;
-use inner::{cors, Inner, OriginFn};
+use inner::{Inner, OriginFn};
 pub use middleware::CorsMiddleware;

--- a/actix-cors/src/lib.rs
+++ b/actix-cors/src/lib.rs
@@ -62,7 +62,7 @@ mod inner;
 mod middleware;
 
 pub use all_or_some::AllOrSome;
-pub use builder::{Cors, CorsFactory};
+pub use builder::Cors;
 pub use error::CorsError;
 use inner::{Inner, OriginFn};
 pub use middleware::CorsMiddleware;

--- a/actix-cors/src/lib.rs
+++ b/actix-cors/src/lib.rs
@@ -60,7 +60,7 @@ mod error;
 mod inner;
 mod middleware;
 
-pub use all_or_some::AllOrSome;
+use all_or_some::AllOrSome;
 pub use builder::Cors;
 pub use error::CorsError;
 use inner::{Inner, OriginFn};

--- a/actix-cors/src/lib.rs
+++ b/actix-cors/src/lib.rs
@@ -22,7 +22,7 @@
 //! #[actix_web::main]
 //! async fn main() -> std::io::Result<()> {
 //!     HttpServer::new(|| {
-//!         let cors = Cors::new()
+//!         let cors = Cors::default()
 //!               .allowed_origin("https://www.rust-lang.org/")
 //!               .allowed_origin_fn(|req| {
 //!                   req.headers
@@ -34,8 +34,7 @@
 //!               .allowed_methods(vec!["GET", "POST"])
 //!               .allowed_headers(vec![http::header::AUTHORIZATION, http::header::ACCEPT])
 //!               .allowed_header(http::header::CONTENT_TYPE)
-//!               .max_age(3600)
-//!               .finish();
+//!               .max_age(3600);
 //!
 //!         App::new()
 //!             .wrap(cors)

--- a/actix-cors/tests/tests.rs
+++ b/actix-cors/tests/tests.rs
@@ -13,9 +13,8 @@ use actix_cors::Cors;
 #[actix_rt::test]
 #[should_panic]
 async fn test_wildcard_origin() {
-    Cors::new()
+    Cors::default()
         .allowed_origin("*")
-        .finish()
         .new_transform(test::ok_service())
         .await
         .unwrap();
@@ -23,7 +22,7 @@ async fn test_wildcard_origin() {
 
 #[actix_rt::test]
 async fn test_not_allowed_origin_fn() {
-    let mut cors = Cors::new()
+    let mut cors = Cors::default()
         .allowed_origin("https://www.example.com")
         .allowed_origin_fn(|req| {
             req.headers
@@ -32,7 +31,6 @@ async fn test_not_allowed_origin_fn() {
                 .filter(|b| b.ends_with(b".unknown.com"))
                 .is_some()
         })
-        .finish()
         .new_transform(test::ok_service())
         .await
         .unwrap();
@@ -68,7 +66,7 @@ async fn test_not_allowed_origin_fn() {
 
 #[actix_rt::test]
 async fn test_allowed_origin_fn() {
-    let mut cors = Cors::new()
+    let mut cors = Cors::default()
         .allowed_origin("https://www.example.com")
         .allowed_origin_fn(|req| {
             req.headers
@@ -77,7 +75,6 @@ async fn test_allowed_origin_fn() {
                 .filter(|b| b.ends_with(b".unknown.com"))
                 .is_some()
         })
-        .finish()
         .new_transform(test::ok_service())
         .await
         .unwrap();
@@ -114,7 +111,7 @@ async fn test_allowed_origin_fn() {
 #[actix_rt::test]
 async fn test_allowed_origin_fn_with_environment() {
     let regex = Regex::new("https:.+\\.unknown\\.com").unwrap();
-    let mut cors = Cors::new()
+    let mut cors = Cors::default()
         .allowed_origin("https://www.example.com")
         .allowed_origin_fn(move |req| {
             req.headers
@@ -123,7 +120,6 @@ async fn test_allowed_origin_fn_with_environment() {
                 .filter(|b| regex.is_match(b))
                 .is_some()
         })
-        .finish()
         .new_transform(test::ok_service())
         .await
         .unwrap();
@@ -159,11 +155,10 @@ async fn test_allowed_origin_fn_with_environment() {
 
 #[actix_rt::test]
 async fn test_multiple_origins_preflight() {
-    let mut cors = Cors::new()
+    let mut cors = Cors::default()
         .allowed_origin("https://example.com")
         .allowed_origin("https://example.org")
         .allowed_methods(vec![Method::GET])
-        .finish()
         .new_transform(test::ok_service())
         .await
         .unwrap();
@@ -199,11 +194,10 @@ async fn test_multiple_origins_preflight() {
 
 #[actix_rt::test]
 async fn test_multiple_origins() {
-    let mut cors = Cors::new()
+    let mut cors = Cors::default()
         .allowed_origin("https://example.com")
         .allowed_origin("https://example.org")
         .allowed_methods(vec![Method::GET])
-        .finish()
         .new_transform(test::ok_service())
         .await
         .unwrap();
@@ -238,7 +232,7 @@ async fn test_multiple_origins() {
 #[actix_rt::test]
 async fn test_response() {
     let exposed_headers = vec![header::AUTHORIZATION, header::ACCEPT];
-    let mut cors = Cors::new()
+    let mut cors = Cors::default()
         .send_wildcard()
         .disable_preflight()
         .max_age(3600)
@@ -246,7 +240,6 @@ async fn test_response() {
         .allowed_headers(exposed_headers.clone())
         .expose_headers(exposed_headers.clone())
         .allowed_header(header::CONTENT_TYPE)
-        .finish()
         .new_transform(test::ok_service())
         .await
         .unwrap();
@@ -286,7 +279,7 @@ async fn test_response() {
     }
 
     let exposed_headers = vec![header::AUTHORIZATION, header::ACCEPT];
-    let mut cors = Cors::new()
+    let mut cors = Cors::default()
         .send_wildcard()
         .disable_preflight()
         .max_age(3600)
@@ -294,7 +287,6 @@ async fn test_response() {
         .allowed_headers(exposed_headers.clone())
         .expose_headers(exposed_headers.clone())
         .allowed_header(header::CONTENT_TYPE)
-        .finish()
         .new_transform(fn_service(|req: ServiceRequest| {
             ok(req.into_response(
                 HttpResponse::Ok().header(header::VARY, "Accept").finish(),
@@ -311,11 +303,10 @@ async fn test_response() {
         resp.headers().get(header::VARY).unwrap().as_bytes()
     );
 
-    let mut cors = Cors::new()
+    let mut cors = Cors::default()
         .disable_vary_header()
         .allowed_origin("https://www.example.com")
         .allowed_origin("https://www.google.com")
-        .finish()
         .new_transform(test::ok_service())
         .await
         .unwrap();
@@ -338,9 +329,8 @@ async fn test_response() {
 
 #[actix_rt::test]
 async fn test_validate_origin() {
-    let mut cors = Cors::new()
+    let mut cors = Cors::default()
         .allowed_origin("https://www.example.com")
-        .finish()
         .new_transform(test::ok_service())
         .await
         .unwrap();
@@ -355,9 +345,8 @@ async fn test_validate_origin() {
 
 #[actix_rt::test]
 async fn test_no_origin_response() {
-    let mut cors = Cors::new()
+    let mut cors = Cors::default()
         .disable_preflight()
-        .finish()
         .new_transform(test::ok_service())
         .await
         .unwrap();
@@ -384,8 +373,7 @@ async fn test_no_origin_response() {
 
 #[actix_rt::test]
 async fn validate_origin_allows_all_origins() {
-    let mut cors = Cors::new()
-        .finish()
+    let mut cors = Cors::permissive()
         .new_transform(test::ok_service())
         .await
         .unwrap();


### PR DESCRIPTION
## PR Type
Refactor


## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
Major changes:
- `CorsFactory` struct is removed
  - Moves the middleware intiailization into new_transform, leveraging InitError instead of panicking
- `impl Default for Cors` is overly-restrictive so you can't accidentally have security flaws when relying on the defaults.
- A `Cors::permissive()` constructor that allows anything.
  - I wanted the name to reflect it being not ideal for production use and the docs state this.
- Adds methods for each property to reset to a permissive state, eg `allow_any_origin` and `expose_any_header`.
  - Rationale is that making it too onerous create a reasonable CORS set up will "encourage" use of `Cors::permissive` too much.
  - Naming bikeshed: could be `allow_all_origins` / `expose_all_headers`.
- Fixes current bug where allowed origin functions are not called if allowed_origins is All
  - Makes the semantics of this field more like "allow exact origins" but I think that's reasonable to expect if you've also defined a vaidate function.
- `CorsError::BadOrigin` is no longer an error because String conversions/comparisons do not occur.



### Notes:
The Transform::InitError system needs to be formalized properly at the actix-web level because this way workers fail to start up, no response is recieved to requests and the process does not crash. It's a big weird and kind of reliant on the developer using `env_logger` to notice the error logs.

I think this should be released as 0.5 as a "beta" period for 1.0.