### PR TITLE
Fix allow_any_header setter

### DIFF
--- a/actix-cors/CHANGES.md
+++ b/actix-cors/CHANGES.md
@@ -1,7 +1,7 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
-
+* Fix `expose_any_header` method, now set the correct field
 
 ## 0.5.0 - 2020-10-19
 * Disallow `*` in `Cors::allowed_origin`. [#114].

--- a/actix-cors/CHANGES.md
+++ b/actix-cors/CHANGES.md
@@ -1,7 +1,7 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
-* Fix `expose_any_header` method, now set the correct field
+* Fix `allow_any_header` method, now set the correct field
 
 ## 0.5.0 - 2020-10-19
 * Disallow `*` in `Cors::allowed_origin`. [#114].

--- a/actix-cors/src/builder.rs
+++ b/actix-cors/src/builder.rs
@@ -234,12 +234,12 @@ impl Cors {
         self
     }
 
-    /// Resets allowed request header list to a state where any origin is accepted.
+    /// Resets allowed request header list to a state where any header is accepted.
     ///
     /// See [`Cors::allowed_headers`] for more info on allowed request headers.
     pub fn allow_any_header(mut self) -> Cors {
         if let Some(cors) = cors(&mut self.inner, &self.error) {
-            cors.allowed_origins = AllOrSome::All;
+            cors.allowed_headers = AllOrSome::All;
         }
 
         self

--- a/actix-cors/tests/tests.rs
+++ b/actix-cors/tests/tests.rs
@@ -404,6 +404,5 @@ async fn test_allow_any_origin_any_method_any_header() {
         .to_srv_request();
 
     let resp = test::call_service(&mut cors, req).await;
-    dbg!(&resp);
     assert_eq!(resp.status(), StatusCode::OK);
 }

--- a/actix-cors/tests/tests.rs
+++ b/actix-cors/tests/tests.rs
@@ -386,3 +386,24 @@ async fn validate_origin_allows_all_origins() {
     let resp = test::call_service(&mut cors, req).await;
     assert_eq!(resp.status(), StatusCode::OK);
 }
+
+#[actix_rt::test]
+async fn test_allow_any_origin_any_method_any_header() {
+    let mut cors = Cors::default()
+        .allow_any_origin()
+        .allow_any_method()
+        .allow_any_header()
+        .new_transform(test::ok_service())
+        .await
+        .unwrap();
+
+    let req = TestRequest::with_header(header::ACCESS_CONTROL_REQUEST_METHOD, "POST")
+        .header(header::ACCESS_CONTROL_REQUEST_HEADERS, "content-type")
+        .header(header::ORIGIN, "https://www.example.com")
+        .method(Method::OPTIONS)
+        .to_srv_request();
+
+    let resp = test::call_service(&mut cors, req).await;
+    dbg!(&resp);
+    assert_eq!(resp.status(), StatusCode::OK);
+}


### PR DESCRIPTION
## PR Type
Bug Fix


## PR Checklist
Check your PR fulfills the following:

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
Fix `allow_any_header` method, setting `allowed_headers` field instead of `allowed_origins`