### PR TITLE
Use re-exported `bytes` items from instead of using them directly

### DIFF
--- a/actix-identity/Cargo.toml
+++ b/actix-identity/Cargo.toml
@@ -26,4 +26,3 @@ time = { version = "0.2.7", default-features = false, features = ["std"] }
 [dev-dependencies]
 actix-rt = "1.1.1"
 actix-http = "2.0.0"
-bytes = "0.5.3"

--- a/actix-protobuf/Cargo.toml
+++ b/actix-protobuf/Cargo.toml
@@ -21,7 +21,6 @@ path = "src/lib.rs"
 [dependencies]
 actix-web = { version = "3.0.0", default_features = false }
 actix-rt = "1.1.1"
-bytes = "0.5"
 futures-util = { version = "0.3.5", default-features = false }
 derive_more = "0.99"
 prost = "0.6.0"

--- a/actix-protobuf/examples/prost-example/Cargo.toml
+++ b/actix-protobuf/examples/prost-example/Cargo.toml
@@ -11,7 +11,6 @@ authors = [
 actix-web = "3.0.0"
 actix-protobuf = { path = "../../" }
 
-bytes = "0.5"
 env_logger = "0.7"
 prost = "0.6.0"
 prost-derive = "0.6.0"

--- a/actix-protobuf/src/lib.rs
+++ b/actix-protobuf/src/lib.rs
@@ -8,7 +8,6 @@ use std::pin::Pin;
 use std::task;
 use std::task::Poll;
 
-use bytes::BytesMut;
 use prost::DecodeError as ProtoBufDecodeError;
 use prost::EncodeError as ProtoBufEncodeError;
 use prost::Message;
@@ -16,6 +15,7 @@ use prost::Message;
 use actix_web::dev::{HttpResponseBuilder, Payload};
 use actix_web::error::{Error, PayloadError, ResponseError};
 use actix_web::http::header::{CONTENT_LENGTH, CONTENT_TYPE};
+use actix_web::web::BytesMut;
 use actix_web::{FromRequest, HttpMessage, HttpRequest, HttpResponse, Responder};
 use futures_util::future::{ready, FutureExt, LocalBoxFuture, Ready};
 use futures_util::StreamExt;

--- a/actix-session/Cargo.toml
+++ b/actix-session/Cargo.toml
@@ -22,7 +22,6 @@ cookie-session = ["actix-web/secure-cookies"]
 [dependencies]
 actix-web = { version = "3.0.0", default_features = false }
 actix-service = "1.0.6"
-bytes = "0.5.3"
 derive_more = "0.99.2"
 futures-util = { version = "0.3.4", default-features = false }
 serde = "1.0"

--- a/actix-session/src/cookie.rs
+++ b/actix-session/src/cookie.rs
@@ -397,8 +397,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use actix_web::web::Bytes;
     use actix_web::{test, web, App};
-    use bytes::Bytes;
 
     #[actix_rt::test]
     async fn cookie_session() {

--- a/actix-web-httpauth/Cargo.toml
+++ b/actix-web-httpauth/Cargo.toml
@@ -22,7 +22,6 @@ path = "src/lib.rs"
 [dependencies]
 actix-web = { version = "3.0.0", default_features = false }
 base64 = "0.13"
-bytes = "0.5"
 futures-util = { version = "0.3", default-features = false }
 
 [dev-dependencies]

--- a/actix-web-httpauth/src/headers/authorization/scheme/basic.rs
+++ b/actix-web-httpauth/src/headers/authorization/scheme/basic.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::str;
 
 use actix_web::http::header::{HeaderValue, IntoHeaderValue, InvalidHeaderValue};
-use bytes::{BufMut, BytesMut};
+use actix_web::web::{BufMut, BytesMut};
 
 use crate::headers::authorization::errors::ParseError;
 use crate::headers::authorization::Scheme;

--- a/actix-web-httpauth/src/headers/authorization/scheme/bearer.rs
+++ b/actix-web-httpauth/src/headers/authorization/scheme/bearer.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::fmt;
 
 use actix_web::http::header::{HeaderValue, IntoHeaderValue, InvalidHeaderValue};
-use bytes::{BufMut, BytesMut};
+use actix_web::web::{BufMut, BytesMut};
 
 use crate::headers::authorization::errors::ParseError;
 use crate::headers::authorization::scheme::Scheme;

--- a/actix-web-httpauth/src/headers/www_authenticate/challenge/basic.rs
+++ b/actix-web-httpauth/src/headers/www_authenticate/challenge/basic.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::str;
 
 use actix_web::http::header::{HeaderValue, IntoHeaderValue, InvalidHeaderValue};
-use bytes::{BufMut, Bytes, BytesMut};
+use actix_web::web::{BufMut, Bytes, BytesMut};
 
 use super::Challenge;
 use crate::utils;

--- a/actix-web-httpauth/src/headers/www_authenticate/challenge/bearer/challenge.rs
+++ b/actix-web-httpauth/src/headers/www_authenticate/challenge/bearer/challenge.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::str;
 
 use actix_web::http::header::{HeaderValue, IntoHeaderValue, InvalidHeaderValue};
-use bytes::{BufMut, Bytes, BytesMut};
+use actix_web::web::{BufMut, Bytes, BytesMut};
 
 use super::super::Challenge;
 use super::{BearerBuilder, Error};

--- a/actix-web-httpauth/src/headers/www_authenticate/challenge/mod.rs
+++ b/actix-web-httpauth/src/headers/www_authenticate/challenge/mod.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Debug, Display};
 
 use actix_web::http::header::IntoHeaderValue;
-use bytes::Bytes;
+use actix_web::web::Bytes;
 
 pub mod basic;
 pub mod bearer;

--- a/actix-web-httpauth/src/utils.rs
+++ b/actix-web-httpauth/src/utils.rs
@@ -1,6 +1,6 @@
 use std::str;
 
-use bytes::BytesMut;
+use actix_web::web::BytesMut;
 
 enum State {
     YieldStr,
@@ -55,7 +55,7 @@ pub fn put_quoted(buf: &mut BytesMut, value: &str) {
 mod tests {
     use std::str;
 
-    use bytes::BytesMut;
+    use actix_web::web::BytesMut;
 
     use super::put_quoted;
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
We could sync with the `bytes` version of `actix-web`.

