### PR TITLE
Fix expose_any_header setter

### DIFF
--- a/actix-cors/CHANGES.md
+++ b/actix-cors/CHANGES.md
@@ -1,8 +1,9 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
+* Fix `expose_any_header` method, now set the correct field. [#143]
 
-* Fix `expose_any_header` method, now set the correct field.
+[#143]: https://github.com/actix/actix-extras/pull/143
 
 ## 0.5.3 - 2020-11-19
 * Fix version spec for `derive_more` dependency.

--- a/actix-cors/CHANGES.md
+++ b/actix-cors/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased - 2020-xx-xx
 
+* Fix `expose_any_header` method, now set the correct field.
 
 ## 0.5.3 - 2020-11-19
 * Fix version spec for `derive_more` dependency.

--- a/actix-cors/src/builder.rs
+++ b/actix-cors/src/builder.rs
@@ -318,7 +318,7 @@ impl Cors {
     /// See [`Cors::expose_headers`] for more info on exposed response headers.
     pub fn expose_any_header(mut self) -> Cors {
         if let Some(cors) = cors(&mut self.inner, &self.error) {
-            cors.allowed_origins = AllOrSome::All;
+            cors.expose_headers = AllOrSome::All;
         }
 
         self


### PR DESCRIPTION
## PR Type

Bug Fix

## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview

Fix `expose_any_header` method, setting `expose_headers` field instead of `allowed_origins`