### PR TITLE
Enable customization of AuthenticationError's response builder

### DIFF
--- a/actix-web-httpauth/CHANGES.md
+++ b/actix-web-httpauth/CHANGES.md
@@ -2,8 +2,10 @@
 
 ## Unreleased - 2020-xx-xx
 * Correct error handling when extracting auth details from request. [#128]
+* Breaking change to core traits and structs, enabling customized error handling. [#152]
 
 [#128]: https://github.com/actix/actix-web-httpauth/pull/128
+[#152]: https://github.com/actix/actix-web-httpauth/pull/152
 
 
 ## 0.5.0 - 2020-09-11

--- a/actix-web-httpauth/examples/middleware-closure.rs
+++ b/actix-web-httpauth/examples/middleware-closure.rs
@@ -1,11 +1,12 @@
 use actix_web::{middleware, web, App, HttpServer};
 
 use actix_web_httpauth::middleware::HttpAuthentication;
+use actix_web_httpauth::extractors::BasicAuth;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     HttpServer::new(|| {
-        let auth = HttpAuthentication::basic(|req, _credentials| async { Ok(req) });
+        let auth = HttpAuthentication::with_fn(|req, _credentials: BasicAuth| async { Ok(req) });
         App::new()
             .wrap(middleware::Logger::default())
             .wrap(auth)

--- a/actix-web-httpauth/examples/middleware-closure.rs
+++ b/actix-web-httpauth/examples/middleware-closure.rs
@@ -1,12 +1,14 @@
 use actix_web::{middleware, web, App, HttpServer};
 
-use actix_web_httpauth::middleware::HttpAuthentication;
 use actix_web_httpauth::extractors::BasicAuth;
+use actix_web_httpauth::middleware::HttpAuthentication;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     HttpServer::new(|| {
-        let auth = HttpAuthentication::with_fn(|req, _credentials: BasicAuth| async { Ok(req) });
+        let auth = HttpAuthentication::with_fn(|req, _credentials: BasicAuth| async {
+            Ok(req)
+        });
         App::new()
             .wrap(middleware::Logger::default())
             .wrap(auth)

--- a/actix-web-httpauth/src/extractors/basic.rs
+++ b/actix-web-httpauth/src/extractors/basic.rs
@@ -104,12 +104,6 @@ impl<B: CompleteErrorResponse> BasicAuth<B> {
     pub fn password(&self) -> Option<&Cow<'static, str>> {
         self.0.password()
     }
-} 
-
-impl<B: CompleteErrorResponse> From<BasicAuth<B>> for PhantomData<B> {
-    fn from(auth: BasicAuth<B>) -> Self {
-        auth.1
-    }
 }
 
 impl<B: CompleteErrorResponse> FromRequest for BasicAuth<B> {

--- a/actix-web-httpauth/src/extractors/basic.rs
+++ b/actix-web-httpauth/src/extractors/basic.rs
@@ -79,7 +79,7 @@ impl<B: CompleteErrorResponse> AuthExtractorConfig for Config<B> {
 ///
 /// ```
 /// use actix_web::{web, App};
-/// use actix_web_httpauth::extractors::basic::{BasicAuth, Config};
+/// use actix_web_httpauth::extractors::basic::BasicAuth;
 ///
 /// async fn index(auth: BasicAuth) -> String {
 ///     format!("Hello, {}!", auth.user_id())
@@ -87,7 +87,7 @@ impl<B: CompleteErrorResponse> AuthExtractorConfig for Config<B> {
 ///
 /// fn main() {
 ///     let app = App::new()
-///         .data(Config::default().realm("Restricted area"))
+///         .data(<BasicAuth>::default_config().realm("Restricted area"))
 ///         .service(web::resource("/index.html").route(web::get().to(index)));
 /// }
 /// ```
@@ -109,6 +109,11 @@ impl<B: CompleteErrorResponse> BasicAuth<B> {
     /// Returns client's password.
     pub fn password(&self) -> Option<&Cow<'static, str>> {
         self.0.password()
+    }
+
+    /// Returns the default BasicAuth configuraion
+    pub fn default_config() -> <Self as FromRequest>::Config {
+        <Self as FromRequest>::Config::default()
     }
 }
 

--- a/actix-web-httpauth/src/extractors/basic.rs
+++ b/actix-web-httpauth/src/extractors/basic.rs
@@ -1,8 +1,8 @@
 //! Extractor for the "Basic" HTTP Authentication Scheme
 
 use std::borrow::Cow;
-use std::marker::PhantomData;
 use std::default::Default;
+use std::marker::PhantomData;
 
 use actix_web::dev::{Payload, ServiceRequest};
 use actix_web::http::header::Header;
@@ -22,7 +22,10 @@ use crate::headers::www_authenticate::basic::Basic as Challenge;
 /// [`WWW-Authenticate`]:
 /// ../../headers/www_authenticate/struct.WwwAuthenticate.html
 #[derive(Debug, Clone, Default)]
-pub struct Config<B: CompleteErrorResponse = DefaultErrorResponse>(Challenge, PhantomData<B>);
+pub struct Config<B: CompleteErrorResponse = DefaultErrorResponse>(
+    Challenge,
+    PhantomData<B>,
+);
 
 impl<B: CompleteErrorResponse> Config<B> {
     /// Set challenge `realm` attribute.
@@ -92,7 +95,10 @@ impl<B: CompleteErrorResponse> AuthExtractorConfig for Config<B> {
 /// [`Config`]: ./struct.Config.html
 /// [app data]: https://docs.rs/actix-web/1.0.0-beta.5/actix_web/struct.App.html#method.data
 #[derive(Debug, Clone)]
-pub struct BasicAuth<B: CompleteErrorResponse = DefaultErrorResponse>(Basic, PhantomData<B>);
+pub struct BasicAuth<B: CompleteErrorResponse = DefaultErrorResponse>(
+    Basic,
+    PhantomData<B>,
+);
 
 impl<B: CompleteErrorResponse> BasicAuth<B> {
     /// Returns client's user-ID.
@@ -118,9 +124,7 @@ impl<B: CompleteErrorResponse> FromRequest for BasicAuth<B> {
         ready(
             Authorization::<Basic>::parse(req)
                 .map(|auth| BasicAuth(auth.into_scheme(), PhantomData))
-                .map_err(|_| {
-                    AuthenticationError::default(req)
-                }),
+                .map_err(|_| AuthenticationError::default(req)),
         )
     }
 }
@@ -130,9 +134,7 @@ impl<B: CompleteErrorResponse> AuthExtractor for BasicAuth<B> {
         ready(
             Authorization::<Basic>::parse(req)
                 .map(|auth| BasicAuth(auth.into_scheme(), PhantomData))
-                .map_err(|_| {
-                    AuthenticationError::default2(req)
-                }),
+                .map_err(|_| AuthenticationError::default2(req)),
         )
     }
 }

--- a/actix-web-httpauth/src/extractors/bearer.rs
+++ b/actix-web-httpauth/src/extractors/bearer.rs
@@ -148,9 +148,9 @@ impl<B: CompleteErrorResponse> AuthenticationError<Config<B>> {
     }
 
     /// Attach error description to the current Authentication error.
-    pub fn with_error_description<D>(mut self, desc: D) -> Self
+    pub fn with_error_description<T>(mut self, desc: T) -> Self
     where
-        D: Into<Cow<'static, str>>,
+        T: Into<Cow<'static, str>>,
     {
         self.challenge_mut().error_description = Some(desc.into());
         self
@@ -159,9 +159,9 @@ impl<B: CompleteErrorResponse> AuthenticationError<Config<B>> {
     /// Attach error URI to the current Authentication error.
     ///
     /// It is up to implementor to provide properly formed absolute URI.
-    pub fn with_error_uri<D>(mut self, uri: D) -> Self
+    pub fn with_error_uri<T>(mut self, uri: T) -> Self
     where
-        D: Into<Cow<'static, str>>,
+        T: Into<Cow<'static, str>>,
     {
         self.challenge_mut().error_uri = Some(uri.into());
         self

--- a/actix-web-httpauth/src/extractors/bearer.rs
+++ b/actix-web-httpauth/src/extractors/bearer.rs
@@ -81,7 +81,7 @@ impl<B: CompleteErrorResponse> AuthExtractorConfig for Config<B> {
 ///
 /// ```
 /// use actix_web::{web, App};
-/// use actix_web_httpauth::extractors::bearer::{BearerAuth, Config};
+/// use actix_web_httpauth::extractors::bearer::BearerAuth;
 ///
 /// async fn index(auth: BearerAuth) -> String {
 ///     format!("Hello, {}!", auth.token())
@@ -90,7 +90,7 @@ impl<B: CompleteErrorResponse> AuthExtractorConfig for Config<B> {
 /// fn main() {
 ///     let app = App::new()
 ///         .data(
-///             Config::default()
+///             <BearerAuth>::default_config()
 ///                 .realm("Restricted area")
 ///                 .scope("email photo"),
 ///         )
@@ -107,6 +107,11 @@ impl<B: CompleteErrorResponse> BearerAuth<B> {
     /// Returns bearer token provided by client.
     pub fn token(&self) -> &str {
         self.0.token()
+    }
+
+    /// Returns the default bearer configuraion
+    pub fn default_config() -> <Self as FromRequest>::Config {
+        <Self as FromRequest>::Config::default()
     }
 }
 

--- a/actix-web-httpauth/src/extractors/bearer.rs
+++ b/actix-web-httpauth/src/extractors/bearer.rs
@@ -18,7 +18,10 @@ pub use crate::headers::www_authenticate::bearer::Error;
 
 /// [BearerAuth](./struct/BearerAuth.html) extractor configuration.
 #[derive(Debug, Clone, Default)]
-pub struct Config<B: CompleteErrorResponse = DefaultErrorResponse>( bearer::Bearer, PhantomData<B> );
+pub struct Config<B: CompleteErrorResponse = DefaultErrorResponse>(
+    bearer::Bearer,
+    PhantomData<B>,
+);
 
 impl<B: CompleteErrorResponse> Config<B> {
     /// Set challenge `scope` attribute.
@@ -95,7 +98,10 @@ impl<B: CompleteErrorResponse> AuthExtractorConfig for Config<B> {
 /// }
 /// ```
 #[derive(Debug, Clone)]
-pub struct BearerAuth<B: CompleteErrorResponse = DefaultErrorResponse>(authorization::Bearer, PhantomData<B>);
+pub struct BearerAuth<B: CompleteErrorResponse = DefaultErrorResponse>(
+    authorization::Bearer,
+    PhantomData<B>,
+);
 
 impl<B: CompleteErrorResponse> BearerAuth<B> {
     /// Returns bearer token provided by client.
@@ -116,9 +122,7 @@ impl<B: CompleteErrorResponse> FromRequest for BearerAuth<B> {
         ready(
             authorization::Authorization::<authorization::Bearer>::parse(req)
                 .map(|auth| BearerAuth(auth.into_scheme(), PhantomData))
-                .map_err(|_| {
-                    AuthenticationError::default(req)
-                }),
+                .map_err(|_| AuthenticationError::default(req)),
         )
     }
 }
@@ -128,9 +132,7 @@ impl<B: CompleteErrorResponse> AuthExtractor for BearerAuth<B> {
         ready(
             authorization::Authorization::<authorization::Bearer>::parse(req)
                 .map(|auth| BearerAuth(auth.into_scheme(), PhantomData))
-                .map_err(|_| {
-                    AuthenticationError::default2(req)
-                }),
+                .map_err(|_| AuthenticationError::default2(req)),
         )
     }
 }

--- a/actix-web-httpauth/src/extractors/config.rs
+++ b/actix-web-httpauth/src/extractors/config.rs
@@ -1,5 +1,9 @@
+use std::marker::PhantomData;
+
 use super::AuthenticationError;
 use crate::headers::www_authenticate::Challenge;
+use super::CompleteErrorResponse;
+use super::AuthExtractor;
 
 /// Trait implemented for types that provides configuration
 /// for the authentication [extractors].
@@ -13,11 +17,67 @@ pub trait AuthExtractorConfig {
     fn into_inner(self) -> Self::Inner;
 }
 
-impl<T> From<T> for AuthenticationError<<T as AuthExtractorConfig>::Inner>
+impl<T, B> From<T> for AuthenticationError<<T as AuthExtractorConfig>::Inner, B>
 where
     T: AuthExtractorConfig,
+    B: CompleteErrorResponse,
 {
     fn from(config: T) -> Self {
         AuthenticationError::new(config.into_inner())
+    }
+}
+
+
+/// Relate AuthExtractorConfig with a CompleteErrorResponse implementation
+pub struct TypedConfig<T, B>
+where
+    T: AuthExtractorConfig,
+    B: CompleteErrorResponse,
+{
+    a: T,
+    _p: PhantomData<B>,
+}
+
+impl<T, B> TypedConfig<T, B>
+where
+    T: AuthExtractorConfig,
+    B: CompleteErrorResponse,
+{
+    /// Relate the config with response implementation of the credential
+    pub fn hint<E, F, A: AuthExtractor<Error = E, Future = F, CompleteResponse = B>>(_: &A, config: T) -> Self {
+        Self::from(config)
+    }
+}
+
+impl<T, B> From<T> for TypedConfig<T, B>
+where
+    T: AuthExtractorConfig,
+    B: CompleteErrorResponse,
+{
+    fn from(config: T) -> Self {
+        Self { a: config, _p: PhantomData }
+    }
+}
+
+impl<T, B> From<TypedConfig<T, B>> for AuthenticationError<<T as AuthExtractorConfig>::Inner, B>
+where
+    T: AuthExtractorConfig,
+    B: CompleteErrorResponse,
+{
+    fn from(config: TypedConfig<T, B>) -> Self {
+        Self::new(config.a.into_inner())
+    }
+}
+
+
+
+impl<C, B> AuthenticationError<C, B>
+where
+    C: Challenge,
+    B: CompleteErrorResponse,
+{
+    /// Construct a AuthenticationError from a config instance with ErrorResponse hint
+    pub fn hinted_from<E, F, T: AuthExtractorConfig<Inner = C>, A: AuthExtractor<Error = E, Future = F, CompleteResponse = B>>(config: T, _: &A) -> Self {
+        Self::new(config.into_inner())
     }
 }

--- a/actix-web-httpauth/src/extractors/config.rs
+++ b/actix-web-httpauth/src/extractors/config.rs
@@ -1,15 +1,14 @@
-// use std::marker::PhantomData;
+use std::fmt::Debug;
 
 use super::AuthenticationError;
-use crate::headers::www_authenticate::Challenge;
 use super::CompleteErrorResponse;
-// use super::AuthExtractor;
+use crate::headers::www_authenticate::Challenge;
 
 /// Trait implemented for types that provides configuration
 /// for the authentication [extractors].
 ///
 /// [extractors]: ./trait.AuthExtractor.html
-pub trait AuthExtractorConfig: 'static + std::fmt::Debug + std::clone::Clone + std::default::Default {
+pub trait AuthExtractorConfig: 'static + Debug + Clone + Default {
     /// Associated challenge type.
     type Inner: Challenge;
 

--- a/actix-web-httpauth/src/extractors/config.rs
+++ b/actix-web-httpauth/src/extractors/config.rs
@@ -1,83 +1,30 @@
-use std::marker::PhantomData;
+// use std::marker::PhantomData;
 
 use super::AuthenticationError;
 use crate::headers::www_authenticate::Challenge;
 use super::CompleteErrorResponse;
-use super::AuthExtractor;
+// use super::AuthExtractor;
 
 /// Trait implemented for types that provides configuration
 /// for the authentication [extractors].
 ///
 /// [extractors]: ./trait.AuthExtractor.html
-pub trait AuthExtractorConfig {
+pub trait AuthExtractorConfig: 'static + std::fmt::Debug + std::clone::Clone + std::default::Default {
     /// Associated challenge type.
     type Inner: Challenge;
+
+    /// Associated error response callback.
+    type Builder: CompleteErrorResponse;
 
     /// Convert the config instance into a HTTP challenge.
     fn into_inner(self) -> Self::Inner;
 }
 
-impl<T, B> From<T> for AuthenticationError<<T as AuthExtractorConfig>::Inner, B>
+impl<T> From<T> for AuthenticationError<T>
 where
     T: AuthExtractorConfig,
-    B: CompleteErrorResponse,
 {
     fn from(config: T) -> Self {
-        AuthenticationError::new(config.into_inner())
-    }
-}
-
-
-/// Relate AuthExtractorConfig with a CompleteErrorResponse implementation
-pub struct TypedConfig<T, B>
-where
-    T: AuthExtractorConfig,
-    B: CompleteErrorResponse,
-{
-    a: T,
-    _p: PhantomData<B>,
-}
-
-impl<T, B> TypedConfig<T, B>
-where
-    T: AuthExtractorConfig,
-    B: CompleteErrorResponse,
-{
-    /// Relate the config with response implementation of the credential
-    pub fn hint<E, F, A: AuthExtractor<Error = E, Future = F, CompleteResponse = B>>(_: &A, config: T) -> Self {
-        Self::from(config)
-    }
-}
-
-impl<T, B> From<T> for TypedConfig<T, B>
-where
-    T: AuthExtractorConfig,
-    B: CompleteErrorResponse,
-{
-    fn from(config: T) -> Self {
-        Self { a: config, _p: PhantomData }
-    }
-}
-
-impl<T, B> From<TypedConfig<T, B>> for AuthenticationError<<T as AuthExtractorConfig>::Inner, B>
-where
-    T: AuthExtractorConfig,
-    B: CompleteErrorResponse,
-{
-    fn from(config: TypedConfig<T, B>) -> Self {
-        Self::new(config.a.into_inner())
-    }
-}
-
-
-
-impl<C, B> AuthenticationError<C, B>
-where
-    C: Challenge,
-    B: CompleteErrorResponse,
-{
-    /// Construct a AuthenticationError from a config instance with ErrorResponse hint
-    pub fn hinted_from<E, F, T: AuthExtractorConfig<Inner = C>, A: AuthExtractor<Error = E, Future = F, CompleteResponse = B>>(config: T, _: &A) -> Self {
-        Self::new(config.into_inner())
+        AuthenticationError::new(config)
     }
 }

--- a/actix-web-httpauth/src/extractors/errors.rs
+++ b/actix-web-httpauth/src/extractors/errors.rs
@@ -171,14 +171,15 @@ impl<T: AuthExtractorConfig> ResponseError for AuthenticationError<T> {
 
 #[cfg(test)]
 mod tests {
+    use super::super::basic::Config as BasicConfig;
     use super::*;
     use crate::headers::www_authenticate::basic::Basic;
-    use super::super::basic::Config as BasicConfig;
     use actix_web::Error;
 
     #[test]
     fn test_status_code_is_preserved_across_error_conversions() {
-        let ae: AuthenticationError<BasicConfig> = AuthenticationError::new2(Basic::default());
+        let ae: AuthenticationError<BasicConfig> =
+            AuthenticationError::new2(Basic::default());
         let expected = ae.status_code;
 
         // Converting the AuthenticationError into a ResponseError should preserve the status code.

--- a/actix-web-httpauth/src/extractors/errors.rs
+++ b/actix-web-httpauth/src/extractors/errors.rs
@@ -102,7 +102,7 @@ impl<T: AuthExtractorConfig> AuthenticationError<T> {
         let challenge = req
             .borrow()
             .app_data::<T>()
-            .map(|config| config.clone())
+            .cloned()
             // TODO: Add trace! about `Default::default` call
             .unwrap_or_else(Default::default);
 
@@ -115,7 +115,7 @@ impl<T: AuthExtractorConfig> AuthenticationError<T> {
         let challenge = req
             .borrow()
             .app_data::<T>()
-            .map(|config| config.clone())
+            .cloned()
             // TODO: Add trace! about `Default::default` call
             .unwrap_or_else(Default::default);
 

--- a/actix-web-httpauth/src/extractors/errors.rs
+++ b/actix-web-httpauth/src/extractors/errors.rs
@@ -1,9 +1,12 @@
+use std::borrow::Borrow;
 use std::error::Error;
 use std::fmt;
-use std::borrow::Borrow;
 
 use actix_web::http::StatusCode;
-use actix_web::{HttpRequest, HttpResponse, ResponseError, FromRequest, dev::HttpResponseBuilder, dev::ServiceRequest};
+use actix_web::{
+    dev::HttpResponseBuilder, dev::ServiceRequest, FromRequest, HttpRequest,
+    HttpResponse, ResponseError,
+};
 
 use crate::headers::www_authenticate::WwwAuthenticate;
 
@@ -86,12 +89,12 @@ impl<T: AuthExtractorConfig> AuthenticationError<T> {
     }
 }
 
-
 impl<T: AuthExtractorConfig> AuthenticationError<T> {
     /// Create new authentication error based on the configuration in req
     pub fn default<R: Borrow<HttpRequest>>(req: R) -> Self {
         // TODO: debug! the original error
-        let challenge = req.borrow()
+        let challenge = req
+            .borrow()
             .app_data::<T>()
             .map(|config| config.clone())
             // TODO: Add trace! about `Default::default` call
@@ -103,7 +106,8 @@ impl<T: AuthExtractorConfig> AuthenticationError<T> {
     /// Create new authentication error based on the configuration in req
     pub fn default2<R: Borrow<ServiceRequest>>(req: R) -> Self {
         // TODO: debug! the original error
-        let challenge = req.borrow()
+        let challenge = req
+            .borrow()
             .app_data::<T>()
             .map(|config| config.clone())
             // TODO: Add trace! about `Default::default` call
@@ -113,12 +117,26 @@ impl<T: AuthExtractorConfig> AuthenticationError<T> {
     }
 
     /// Create new authentication error based on the configuration in req
-    pub fn default_hinted<R: Borrow<HttpRequest>, F, A: AuthExtractor + FromRequest<Error = Self, Future = F, Config = T>>(req: R, _: &A) -> Self {
+    pub fn default_hinted<
+        R: Borrow<HttpRequest>,
+        F,
+        A: AuthExtractor + FromRequest<Error = Self, Future = F, Config = T>,
+    >(
+        req: R,
+        _: &A,
+    ) -> Self {
         Self::default(req)
     }
 
     /// Create new authentication error based on the configuration in req
-    pub fn default_hinted2<R: Borrow<ServiceRequest>, F, A: AuthExtractor + FromRequest<Error = Self, Future = F, Config = T>>(req: R, _: &A) -> Self {
+    pub fn default_hinted2<
+        R: Borrow<ServiceRequest>,
+        F,
+        A: AuthExtractor + FromRequest<Error = Self, Future = F, Config = T>,
+    >(
+        req: R,
+        _: &A,
+    ) -> Self {
         Self::default2(req)
     }
 }
@@ -136,7 +154,7 @@ impl<T: AuthExtractorConfig> ResponseError for AuthenticationError<T> {
         <T as AuthExtractorConfig>::Builder::complete_response(
             HttpResponse::build(self.status_code)
                 // TODO: Get rid of the `.clone()`
-                .set(WwwAuthenticate(self.challenge.clone()))
+                .set(WwwAuthenticate(self.challenge.clone())),
         )
     }
 

--- a/actix-web-httpauth/src/extractors/errors.rs
+++ b/actix-web-httpauth/src/extractors/errors.rs
@@ -1,30 +1,68 @@
 use std::error::Error;
 use std::fmt;
+use std::marker::PhantomData;
 
 use actix_web::http::StatusCode;
-use actix_web::{HttpResponse, ResponseError};
+use actix_web::{HttpResponse, ResponseError, dev::HttpResponseBuilder};
 
 use crate::headers::www_authenticate::Challenge;
 use crate::headers::www_authenticate::WwwAuthenticate;
+
+/// Complete the error response, used to override the response of AuthenticationError
+///
+/// # Example
+///
+/// ```
+/// struct MyErrorResponse {}
+/// impl CompleteResponse for MyErrorResponse {
+///   fn complete_response(builder: &mut HttpResponseBuilder) -> HttpResponse {
+///     builder.message_body("Unauthorized")
+///   }
+/// }
+///
+///
+/// type MyBasicAuth = BasicAuth<ApiErrorResponse>;
+///
+/// #[get("/api/")]
+/// fn api_index(credential: MyBasicAuth) -> impl Responder {
+///   debug!("Hello, {}", credential.user_id());
+///   Response::Ok().json(ApiStatus::Ok)
+/// }
+/// ```
+pub trait CompleteErrorResponse: 'static + std::fmt::Debug {
+    /// Modify the response builder and complete the response
+    /// e.g. `builder.finish()`
+    fn complete_response(builder: &mut HttpResponseBuilder) -> HttpResponse;
+}
+
+#[derive(Debug)]
+pub struct DefaultErrorResponse {}
+impl CompleteErrorResponse for DefaultErrorResponse {
+    fn complete_response(builder: &mut HttpResponseBuilder) -> HttpResponse {
+        builder.finish()
+    }
+}
 
 /// Authentication error returned by authentication extractors.
 ///
 /// Different extractors may extend `AuthenticationError` implementation
 /// in order to provide access to inner challenge fields.
 #[derive(Debug)]
-pub struct AuthenticationError<C: Challenge> {
+pub struct AuthenticationError<C: Challenge, B: CompleteErrorResponse> {
     challenge: C,
     status_code: StatusCode,
+    _builder: PhantomData<B>,
 }
 
-impl<C: Challenge> AuthenticationError<C> {
+impl<C: Challenge, B: CompleteErrorResponse> AuthenticationError<C, B> {
     /// Creates new authentication error from the provided `challenge`.
     ///
     /// By default returned error will resolve into the `HTTP 401` status code.
-    pub fn new(challenge: C) -> AuthenticationError<C> {
+    pub fn new(challenge: C) -> AuthenticationError<C, B> {
         AuthenticationError {
             challenge,
             status_code: StatusCode::UNAUTHORIZED,
+            _builder: PhantomData,
         }
     }
 
@@ -42,20 +80,21 @@ impl<C: Challenge> AuthenticationError<C> {
     }
 }
 
-impl<C: Challenge> fmt::Display for AuthenticationError<C> {
+impl<C: Challenge, B: CompleteErrorResponse> fmt::Display for AuthenticationError<C, B> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.status_code, f)
     }
 }
 
-impl<C: 'static + Challenge> Error for AuthenticationError<C> {}
+impl<C: 'static + Challenge, B: CompleteErrorResponse> Error for AuthenticationError<C, B> {}
 
-impl<C: 'static + Challenge> ResponseError for AuthenticationError<C> {
+impl<C: 'static + Challenge, B: CompleteErrorResponse> ResponseError for AuthenticationError<C, B> {
     fn error_response(&self) -> HttpResponse {
-        HttpResponse::build(self.status_code)
-            // TODO: Get rid of the `.clone()`
-            .set(WwwAuthenticate(self.challenge.clone()))
-            .finish()
+        B::complete_response(
+            HttpResponse::build(self.status_code)
+                // TODO: Get rid of the `.clone()`
+                .set(WwwAuthenticate(self.challenge.clone()))
+        )
     }
 
     fn status_code(&self) -> StatusCode {

--- a/actix-web-httpauth/src/extractors/mod.rs
+++ b/actix-web-httpauth/src/extractors/mod.rs
@@ -20,7 +20,6 @@ pub use self::errors::{AuthenticationError, CompleteErrorResponse};
 /// You will not need it unless you want to implement your own
 /// authentication scheme.
 pub trait AuthExtractor: Sized + actix_web::FromRequest {
-
     /// Parse the authentication credentials from the actix' `ServiceRequest`.
     fn from_service_request(req: &ServiceRequest) -> Self::Future;
 }

--- a/actix-web-httpauth/src/extractors/mod.rs
+++ b/actix-web-httpauth/src/extractors/mod.rs
@@ -10,6 +10,9 @@ mod errors;
 pub use self::config::AuthExtractorConfig;
 pub use self::errors::{AuthenticationError, CompleteErrorResponse};
 
+pub use basic::BasicAuth;
+pub use bearer::BearerAuth;
+
 /// Trait implemented by types that can extract
 /// HTTP authentication scheme credentials from the request.
 ///

--- a/actix-web-httpauth/src/extractors/mod.rs
+++ b/actix-web-httpauth/src/extractors/mod.rs
@@ -9,8 +9,8 @@ pub mod bearer;
 mod config;
 mod errors;
 
-pub use self::config::AuthExtractorConfig;
-pub use self::errors::AuthenticationError;
+pub use self::config::{AuthExtractorConfig, TypedConfig};
+pub use self::errors::{AuthenticationError, CompleteErrorResponse};
 
 /// Trait implemented by types that can extract
 /// HTTP authentication scheme credentials from the request.
@@ -27,6 +27,9 @@ pub trait AuthExtractor: Sized {
 
     /// Future that resolves into extracted credentials type.
     type Future: Future<Output = Result<Self, Self::Error>>;
+
+    /// The associated CompleteErrorResponse hint
+    type CompleteResponse: CompleteErrorResponse;
 
     /// Parse the authentication credentials from the actix' `ServiceRequest`.
     fn from_service_request(req: &ServiceRequest) -> Self::Future;

--- a/actix-web-httpauth/src/extractors/mod.rs
+++ b/actix-web-httpauth/src/extractors/mod.rs
@@ -1,15 +1,13 @@
 //! Type-safe authentication information extractors
 
 use actix_web::dev::ServiceRequest;
-use actix_web::Error;
-use std::future::Future;
 
 pub mod basic;
 pub mod bearer;
 mod config;
 mod errors;
 
-pub use self::config::{AuthExtractorConfig, TypedConfig};
+pub use self::config::AuthExtractorConfig;
 pub use self::errors::{AuthenticationError, CompleteErrorResponse};
 
 /// Trait implemented by types that can extract
@@ -21,15 +19,7 @@ pub use self::errors::{AuthenticationError, CompleteErrorResponse};
 ///
 /// You will not need it unless you want to implement your own
 /// authentication scheme.
-pub trait AuthExtractor: Sized {
-    /// The associated error which can be returned.
-    type Error: Into<Error>;
-
-    /// Future that resolves into extracted credentials type.
-    type Future: Future<Output = Result<Self, Self::Error>>;
-
-    /// The associated CompleteErrorResponse hint
-    type CompleteResponse: CompleteErrorResponse;
+pub trait AuthExtractor: Sized + actix_web::FromRequest {
 
     /// Parse the authentication credentials from the actix' `ServiceRequest`.
     fn from_service_request(req: &ServiceRequest) -> Self::Future;

--- a/actix-web-httpauth/src/middleware.rs
+++ b/actix-web-httpauth/src/middleware.rs
@@ -17,7 +17,7 @@ use futures_util::{
     task::{Context, Poll},
 };
 
-use crate::extractors::{basic, bearer, AuthExtractor};
+use crate::extractors::{basic, bearer, AuthExtractor, CompleteErrorResponse};
 
 /// Middleware for checking HTTP authentication.
 ///
@@ -51,9 +51,9 @@ where
     }
 }
 
-impl<F, O> HttpAuthentication<basic::BasicAuth, F>
+impl<F, O, B: CompleteErrorResponse> HttpAuthentication<basic::BasicAuth<B>, F>
 where
-    F: Fn(ServiceRequest, basic::BasicAuth) -> O,
+    F: Fn(ServiceRequest, basic::BasicAuth<B>) -> O,
     O: Future<Output = Result<ServiceRequest, Error>>,
 {
     /// Construct `HttpAuthentication` middleware for the HTTP "Basic" authentication scheme.
@@ -83,9 +83,9 @@ where
     }
 }
 
-impl<F, O> HttpAuthentication<bearer::BearerAuth, F>
+impl<F, O, B: CompleteErrorResponse> HttpAuthentication<bearer::BearerAuth<B>, F>
 where
-    F: Fn(ServiceRequest, bearer::BearerAuth) -> O,
+    F: Fn(ServiceRequest, bearer::BearerAuth<B>) -> O,
     O: Future<Output = Result<ServiceRequest, Error>>,
 {
     /// Construct `HttpAuthentication` middleware for the HTTP "Bearer" authentication scheme.


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature / Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [X] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

- Try to implement #13
- Breaking change to core traits and structs in actix-web-httpauth:
  - Add `CompleteErrorResponse` trait.
  - Make `AuthExtractor` subtrait of `actix_web::FromRequest`, remove duplicated type information.
  - Add `type Builder: CompleteErrorResponse` in trait `AuthExtractorConfig`.
  - Change type parameter of `AuthenticationError` from `Challenge` to `AuthExtractorConfig`.
  - Add type paramerer `B: CompleteErrorResponse` for serveral structs.
  - `Config<B>`, instead of `Challenge`, should be provided as `App::app_data` for requests, enabling the customization of `CompleteErrorResponse`

I tried my best to preserve the interface with default type parameter. However, the construction of `AuthenticationError` is much more complicated in this modification. So i created fn `AuthenticationError::default` and fn `AuthenticationError::default_hinted` to workaround (and try to standardize the construction of `AuthenticationError`).

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
