### PR TITLE
allow session-only cookies

### DIFF
--- a/actix-redis/CHANGES.md
+++ b/actix-redis/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased - 2020-xx-xx
 * Implement `std::error::Error` for `Error` [#135]
+* Allow the removal of Max-Age for session-only cookies
 
 ## 0.9.1 - 2020-09-12
 * Enforce minimum redis-async version of 0.6.3 to workaround breaking patch change.

--- a/actix-redis/CHANGES.md
+++ b/actix-redis/CHANGES.md
@@ -2,7 +2,9 @@
 
 ## Unreleased - 2020-xx-xx
 * Implement `std::error::Error` for `Error` [#135]
-* Allow the removal of Max-Age for session-only cookies
+* Allow the removal of Max-Age for session-only cookies. [#161]
+
+[#161]: https://github.com/actix/actix-extras/pull/161
 
 ## 0.9.1 - 2020-09-12
 * Enforce minimum redis-async version of 0.6.3 to workaround breaking patch change.

--- a/actix-redis/src/session.rs
+++ b/actix-redis/src/session.rs
@@ -80,8 +80,8 @@ impl RedisSession {
     }
 
     /// Set custom cookie max-age
-    pub fn cookie_max_age(mut self, max_age: Duration) -> Self {
-        Rc::get_mut(&mut self.0).unwrap().max_age = Some(max_age);
+    pub fn cookie_max_age(mut self, max_age: Option<Duration>) -> Self {
+        Rc::get_mut(&mut self.0).unwrap().max_age = max_age;
         self
     }
 

--- a/actix-redis/src/session.rs
+++ b/actix-redis/src/session.rs
@@ -80,6 +80,7 @@ impl RedisSession {
     }
 
     /// Set custom cookie max-age
+    /// Use `None` for session-only cookies
     pub fn cookie_max_age(mut self, max_age: Option<Duration>) -> Self {
         Rc::get_mut(&mut self.0).unwrap().max_age = max_age;
         self
@@ -450,6 +451,7 @@ mod test {
         // Step 1:  GET index
         //   - set-cookie actix-session will be in response (session cookie #1)
         //   - response should be: {"counter": 0, "user_id": None}
+        //   - cookie should have default max-age of 7 days
         // Step 2:  GET index, including session cookie #1 in request
         //   - set-cookie will *not* be in response
         //   - response should be: {"counter": 0, "user_id": None}
@@ -510,6 +512,7 @@ mod test {
                 counter: 0
             }
         );
+        assert_eq!(cookie_1.max_age(), Some(Duration::days(7)));
 
         // Step 2:  GET index, including session cookie #1 in request
         //   - set-cookie will *not* be in response
@@ -666,5 +669,34 @@ mod test {
             .find(|c| c.name() == "test-session")
             .unwrap();
         assert_ne!(cookie_5.value(), cookie_2.value());
+    }
+
+    #[actix_rt::test]
+    async fn test_max_age_session_only() {
+        //
+        // Test that removing max_age results in a session-only cookie
+        //
+        let srv = test::start(|| {
+            App::new()
+                .wrap(
+                    RedisSession::new("127.0.0.1:6379", &[0; 32])
+                        .cookie_name("test-session")
+                        .cookie_max_age(None),
+                )
+                .wrap(middleware::Logger::default())
+                .service(resource("/").route(get().to(index)))
+        });
+
+        let req = srv.get("/").send();
+        let resp = req.await.unwrap();
+        let cookie = resp
+            .cookies()
+            .unwrap()
+            .clone()
+            .into_iter()
+            .find(|c| c.name() == "test-session")
+            .unwrap();
+
+        assert_eq!(cookie.max_age(), None);
     }
 }

--- a/actix-redis/src/session.rs
+++ b/actix-redis/src/session.rs
@@ -81,8 +81,8 @@ impl RedisSession {
 
     /// Set custom cookie max-age
     /// Use `None` for session-only cookies
-    pub fn cookie_max_age(mut self, max_age: Option<Duration>) -> Self {
-        Rc::get_mut(&mut self.0).unwrap().max_age = max_age;
+    pub fn cookie_max_age(mut self, max_age: impl Into<Option<Duration>>) -> Self {
+        Rc::get_mut(&mut self.0).unwrap().max_age = max_age.into();
         self
     }
 

--- a/actix-web-httpauth/src/headers/authorization/scheme/basic.rs
+++ b/actix-web-httpauth/src/headers/authorization/scheme/basic.rs
@@ -115,7 +115,7 @@ impl IntoHeaderValue for Basic {
         let encoded = base64::encode(&credentials);
         let mut value = BytesMut::with_capacity(6 + encoded.len());
         value.put(&b"Basic "[..]);
-        value.put(&encoded.as_bytes()[..]);
+        value.put(encoded.as_bytes());
 
         HeaderValue::from_maybe_shared(value.freeze())
     }


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
Feature

## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview

When neither Expire nor Max-Age are present in the `Set-Cookie` header, the browser interprets the cookie as session-only and will be deleted when the browser is closed.

Currently, `RedisSession` public methods don't allow to have session-only cookies even though it seems ready to handle session-only cookies. The `RedisSession` has an Inner with a `max-age` which is an `Option<Duration>` and there is already logic not to include Max-Age if the duration is none. However, there is no way for users to set the max-age as `None`

This PR fixes that by changing the argument of the `set_max_age` function. 

There would be a breaking change for users that have modified the default value, since they would have to pass an Option

I couldn't find any relevant existing tests for this particular module but if this change looks OK, I'll add them
