### PR TITLE
fix actix-redis by revert most recent changes

### DIFF
--- a/actix-redis/Cargo.toml
+++ b/actix-redis/Cargo.toml
@@ -22,8 +22,8 @@ default = ["web"]
 
 # actix-web integration
 web = [
-    "actix-service",
-    "actix-web",
+    "actix-web/cookies",
+    "actix-web/secure-cookies",
     "actix-session/cookie-session",
     "rand",
     "serde",
@@ -31,27 +31,30 @@ web = [
 ]
 
 [dependencies]
-log = "0.4.6"
-derive_more = "0.99.2"
-futures-util = { version = "0.3.7", default-features = false }
-futures-channel = { version = "0.3.5", default-features = false }
-redis-async = "0.9"
-time = "0.2.23"
-actix-rt = "2"
-tokio = "1"
-tokio-util = "0.6"
+actix = { version = "0.11.0", default-features = false }
+actix-rt = { version = "2.1", default-features = false }
+actix-service = "2.0.0-beta.5"
+actix-tls = { version = "3.0.0-beta.4", default-features = false, features = ["connect"] }
 
-trust-dns-resolver = { version = "0.20.0", default-features = false, features = ["tokio-runtime", "system-config"] }
+log = "0.4.6"
+backoff = "0.2.1"
+derive_more = "0.99.2"
+futures-core = { version = "0.3.7", default-features = false }
+redis2 = { package = "redis", version = "0.19.0", features = ["tokio-comp", "tokio-native-tls-comp"] }
+redis-async = { version = "0.8", default-features = false, features = ["tokio10"] }
+time = "0.2.23"
+tokio = { version = "1", features = ["sync"] }
+tokio-util = "0.6.1"
 
 # actix-session
-actix-web = { version = "4.0.0-beta.4", default_features = false, optional = true }
-actix-http = { version = "3.0.0-beta.4", optional = true }
-actix-service = { version = "2.0.0-beta.5", optional = true }
+actix-web = { version = "4.0.0-beta.3", default_features = false, optional = true }
 actix-session = { version = "0.4.0", optional = true }
-rand = { version = "0.8", optional = true }
+rand = { version = "0.8.0", optional = true }
 serde = { version = "1.0.101", optional = true }
 serde_json = { version = "1.0.40", optional = true }
 
 [dev-dependencies]
-env_logger = "0.8"
+actix-http = "3.0.0-beta.4"
+actix-rt = "2.1"
+env_logger = "0.7"
 serde_derive = "1.0"

--- a/actix-redis/src/lib.rs
+++ b/actix-redis/src/lib.rs
@@ -3,7 +3,7 @@
 #![deny(rust_2018_idioms)]
 
 mod redis;
-pub use redis::RedisClient;
+pub use redis::{Command, RedisActor};
 
 use derive_more::{Display, Error, From};
 
@@ -25,12 +25,6 @@ pub enum Error {
     /// Cancel all waters when connection get dropped
     #[display(fmt = "Redis: Disconnected")]
     Disconnected,
-    /// Invalid address
-    #[display(fmt = "Redis: Invalid address")]
-    InvalidAddress,
-    /// DNS resolve error
-    #[display(fmt = "Redis: DNS resolve error")]
-    ResolveError,
 }
 
 #[cfg(feature = "web")]

--- a/actix-redis/src/redis.rs
+++ b/actix-redis/src/redis.rs
@@ -1,98 +1,141 @@
 use std::collections::VecDeque;
-use std::net::SocketAddr;
+use std::io;
 
-use redis_async::client::{paired_connect, PairedConnection};
-use redis_async::resp::RespValue;
-use tokio::sync::Mutex;
-use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
-use trust_dns_resolver::TokioAsyncResolver as AsyncResolver;
+use actix::prelude::*;
+use actix_rt::net::TcpStream;
+use actix_service::boxed::{service, BoxService};
+use actix_tls::connect::{default_connector, Connect, ConnectError, Connection};
+use backoff::backoff::Backoff;
+use backoff::ExponentialBackoff;
+use log::{error, info, warn};
+use redis_async::error::Error as RespError;
+use redis_async::resp::{RespCodec, RespValue};
+use tokio::io::{split, WriteHalf};
+use tokio::sync::oneshot;
+use tokio_util::codec::FramedRead;
 
 use crate::Error;
 
-pub struct RedisClient {
-    addr: String,
-    connection: Mutex<Option<PairedConnection>>,
+/// Command for send data to Redis
+#[derive(Debug)]
+pub struct Command(pub RespValue);
+
+impl Message for Command {
+    type Result = Result<RespValue, Error>;
 }
 
-impl RedisClient {
-    pub fn new(addr: impl Into<String>) -> Self {
-        Self {
-            addr: addr.into(),
-            connection: Mutex::new(None),
+/// Redis communication actor
+pub struct RedisActor {
+    addr: String,
+    connector: BoxService<Connect<String>, Connection<String, TcpStream>, ConnectError>,
+    backoff: ExponentialBackoff,
+    cell: Option<actix::io::FramedWrite<RespValue, WriteHalf<TcpStream>, RespCodec>>,
+    queue: VecDeque<oneshot::Sender<Result<RespValue, Error>>>,
+}
+
+impl RedisActor {
+    /// Start new `Supervisor` with `RedisActor`.
+    pub fn start<S: Into<String>>(addr: S) -> Addr<RedisActor> {
+        let addr = addr.into();
+
+        let backoff = ExponentialBackoff {
+            max_elapsed_time: None,
+            ..Default::default()
+        };
+
+        Supervisor::start(|_| RedisActor {
+            addr,
+            connector: service(default_connector()),
+            cell: None,
+            backoff,
+            queue: VecDeque::new(),
+        })
+    }
+}
+
+impl Actor for RedisActor {
+    type Context = Context<Self>;
+
+    fn started(&mut self, ctx: &mut Context<Self>) {
+        let req = Connect::new(self.addr.to_owned());
+        self.connector
+            .call(req)
+            .into_actor(self)
+            .map(|res, act, ctx| match res {
+                Ok(conn) => {
+                    let stream = conn.into_parts().0;
+                    info!("Connected to redis server: {}", act.addr);
+
+                    let (r, w) = split(stream);
+
+                    // configure write side of the connection
+                    let framed = actix::io::FramedWrite::new(w, RespCodec, ctx);
+                    act.cell = Some(framed);
+
+                    // read side of the connection
+                    ctx.add_stream(FramedRead::new(r, RespCodec));
+
+                    act.backoff.reset();
+                }
+                Err(err) => {
+                    error!("Can not connect to redis server: {}", err);
+                    // re-connect with backoff time.
+                    // we stop current context, supervisor will restart it.
+                    if let Some(timeout) = act.backoff.next_backoff() {
+                        ctx.run_later(timeout, |_, ctx| ctx.stop());
+                    }
+                }
+            })
+            .wait(ctx);
+    }
+}
+
+impl Supervised for RedisActor {
+    fn restarting(&mut self, _: &mut Self::Context) {
+        self.cell.take();
+        for tx in self.queue.drain(..) {
+            let _ = tx.send(Err(Error::Disconnected));
         }
     }
+}
 
-    async fn get_connection(&self) -> Result<PairedConnection, Error> {
-        let mut connection = self.connection.lock().await;
-        if let Some(ref connection) = *connection {
-            return Ok(connection.clone());
-        }
+impl actix::io::WriteHandler<io::Error> for RedisActor {
+    fn error(&mut self, err: io::Error, _: &mut Self::Context) -> Running {
+        warn!("Redis connection dropped: {} error: {}", self.addr, err);
+        Running::Stop
+    }
+}
 
-        let mut addrs = resolve(&self.addr).await?;
-        loop {
-            // try to connect
-            let socket_addr = addrs.pop_front().ok_or_else(|| {
-                log::warn!("Cannot connect to {}.", self.addr);
-                Error::NotConnected
-            })?;
-            match paired_connect(socket_addr).await {
-                Ok(conn) => {
-                    *connection = Some(conn.clone());
-                    return Ok(conn);
+impl StreamHandler<Result<RespValue, RespError>> for RedisActor {
+    fn handle(&mut self, msg: Result<RespValue, RespError>, ctx: &mut Self::Context) {
+        match msg {
+            Err(e) => {
+                if let Some(tx) = self.queue.pop_front() {
+                    let _ = tx.send(Err(e.into()));
                 }
-                Err(err) => log::warn!(
-                    "Attempt to connect to {} as {} failed: {}.",
-                    self.addr,
-                    socket_addr,
-                    err
-                ),
+                ctx.stop();
+            }
+            Ok(val) => {
+                if let Some(tx) = self.queue.pop_front() {
+                    let _ = tx.send(Ok(val));
+                }
             }
         }
     }
-
-    pub async fn send(&self, req: RespValue) -> Result<RespValue, Error> {
-        let res = self.get_connection().await?.send(req).await?;
-        Ok(res)
-    }
 }
 
-fn parse_addr(addr: &str, default_port: u16) -> Option<(&str, u16)> {
-    // split the string by ':' and convert the second part to u16
-    let mut parts_iter = addr.splitn(2, ':');
-    let host = parts_iter.next()?;
-    let port_str = parts_iter.next().unwrap_or("");
-    let port: u16 = port_str.parse().unwrap_or(default_port);
-    Some((host, port))
-}
+impl Handler<Command> for RedisActor {
+    type Result = ResponseFuture<Result<RespValue, Error>>;
 
-async fn resolve(addr: &str) -> Result<VecDeque<SocketAddr>, Error> {
-    // try to parse as a regular SocketAddr first
-    if let Ok(addr) = addr.parse::<SocketAddr>() {
-        let mut addrs = VecDeque::new();
-        addrs.push_back(addr);
-        return Ok(addrs);
+    fn handle(&mut self, msg: Command, _: &mut Self::Context) -> Self::Result {
+        let (tx, rx) = oneshot::channel();
+        if let Some(ref mut cell) = self.cell {
+            self.queue.push_back(tx);
+            cell.write(msg.0);
+        } else {
+            let _ = tx.send(Err(Error::NotConnected));
+        }
+
+        Box::pin(async move { rx.await.map_err(|_| Error::Disconnected)? })
     }
-
-    let (host, port) = parse_addr(addr, 6379).ok_or(Error::InvalidAddress)?;
-
-    // we need to do dns resolution
-    let resolver = AsyncResolver::tokio_from_system_conf()
-        .or_else(|err| {
-            log::warn!("Cannot create system DNS resolver: {}", err);
-            AsyncResolver::tokio(ResolverConfig::default(), ResolverOpts::default())
-        })
-        .map_err(|err| {
-            log::error!("Cannot create DNS resolver: {}", err);
-            Error::ResolveError
-        })?;
-
-    let addrs = resolver
-        .lookup_ip(host)
-        .await
-        .map_err(|_| Error::ResolveError)?
-        .into_iter()
-        .map(|ip| SocketAddr::new(ip, port))
-        .collect();
-
-    Ok(addrs)
 }


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Revert most changes done to actix-redis by https://github.com/actix/actix-extras/pull/144

Reason:
1.  One big point of compile time improvement is from drop trust-dns and use a more light, simple and widely work dns resolver. Import it blindly again in some actix-* repo would void this effort and result in bloat dep tree once again when end user could expect otherwise.
2.  There is dns resolve service in actix-tls crate. The last thing we want is re-write the same logic everywhere.
3.  There is no point abondon working code in favor of something doing the same thing or could end up more limiting.(Please let me know if there is benefit by using redis client directly. As there is no changelog for this change to explain the intention and benefit)


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
