### PR TITLE
WIP web-v4.0.0-beta.6 patch

### DIFF
--- a/actix-cors/src/error.rs
+++ b/actix-cors/src/error.rs
@@ -1,4 +1,4 @@
-use actix_web::{http::StatusCode, HttpResponse, ResponseError};
+use actix_web::{http::StatusCode, BaseHttpResponse, ResponseError};
 
 use derive_more::{Display, Error};
 
@@ -50,7 +50,7 @@ impl ResponseError for CorsError {
         StatusCode::BAD_REQUEST
     }
 
-    fn error_response(&self) -> HttpResponse {
-        HttpResponse::with_body(StatusCode::BAD_REQUEST, self.to_string().into())
+    fn error_response(&self) -> BaseHttpResponse<actix_web::dev::Body> {
+        BaseHttpResponse::with_body(StatusCode::BAD_REQUEST, self.to_string().into())
     }
 }

--- a/actix-identity/src/cookie.rs
+++ b/actix-identity/src/cookie.rs
@@ -4,7 +4,7 @@ use futures_util::future::{ready, Ready};
 use serde::{Deserialize, Serialize};
 use time::Duration;
 
-use actix_web::{HttpMessage, HttpRequest, cookie::{Cookie, CookieJar, Key, SameSite}, dev::{ServiceRequest, ServiceResponse}, error::{Error, JsonPayloadError, Result}, http::header::{self, HeaderValue}};
+use actix_web::{HttpMessage, cookie::{Cookie, CookieJar, Key, SameSite}, dev::{ServiceRequest, ServiceResponse}, error::{Error, JsonPayloadError, Result}, http::header::{self, HeaderValue}};
 
 use crate::IdentityPolicy;
 

--- a/actix-identity/src/cookie.rs
+++ b/actix-identity/src/cookie.rs
@@ -4,7 +4,13 @@ use futures_util::future::{ready, Ready};
 use serde::{Deserialize, Serialize};
 use time::Duration;
 
-use actix_web::{HttpMessage, cookie::{Cookie, CookieJar, Key, SameSite}, dev::{ServiceRequest, ServiceResponse}, error::{Error, JsonPayloadError, Result}, http::header::{self, HeaderValue}};
+use actix_web::{
+    cookie::{Cookie, CookieJar, Key, SameSite},
+    dev::{ServiceRequest, ServiceResponse},
+    error::{Error, JsonPayloadError, Result},
+    http::header::{self, HeaderValue},
+    HttpMessage,
+};
 
 use crate::IdentityPolicy;
 
@@ -71,8 +77,11 @@ impl CookieIdentityInner {
             }
         });
 
-        let mut cookie =
-            Cookie::new(self.name.clone(), val.unwrap_or_else(|| Ok(String::new())).map_err(|err| JsonPayloadError::Deserialize(err))?);
+        let mut cookie = Cookie::new(
+            self.name.clone(),
+            val.unwrap_or_else(|| Ok(String::new()))
+                .map_err(|err| JsonPayloadError::Deserialize(err))?,
+        );
         cookie.set_path(self.path.clone());
         cookie.set_secure(self.secure);
         cookie.set_http_only(true);

--- a/actix-protobuf/src/lib.rs
+++ b/actix-protobuf/src/lib.rs
@@ -12,7 +12,7 @@ use prost::DecodeError as ProtoBufDecodeError;
 use prost::EncodeError as ProtoBufEncodeError;
 use prost::Message;
 
-use actix_web::dev::{HttpResponseBuilder, Payload};
+use actix_web::{BaseHttpResponse, HttpResponseBuilder, dev::{Payload}};
 use actix_web::error::{Error, PayloadError, ResponseError};
 use actix_web::http::header::{CONTENT_LENGTH, CONTENT_TYPE};
 use actix_web::web::BytesMut;
@@ -40,7 +40,7 @@ pub enum ProtoBufPayloadError {
 }
 
 impl ResponseError for ProtoBufPayloadError {
-    fn error_response(&self) -> HttpResponse {
+    fn error_response(&self) -> BaseHttpResponse<actix_web::dev::Body> {
         match *self {
             ProtoBufPayloadError::Overflow => HttpResponse::PayloadTooLarge().into(),
             _ => HttpResponse::BadRequest().into(),

--- a/actix-protobuf/src/lib.rs
+++ b/actix-protobuf/src/lib.rs
@@ -12,10 +12,10 @@ use prost::DecodeError as ProtoBufDecodeError;
 use prost::EncodeError as ProtoBufEncodeError;
 use prost::Message;
 
-use actix_web::{BaseHttpResponse, HttpResponseBuilder, dev::{Payload}};
 use actix_web::error::{Error, PayloadError, ResponseError};
 use actix_web::http::header::{CONTENT_LENGTH, CONTENT_TYPE};
 use actix_web::web::BytesMut;
+use actix_web::{dev::Payload, BaseHttpResponse, HttpResponseBuilder};
 use actix_web::{FromRequest, HttpMessage, HttpRequest, HttpResponse, Responder};
 use futures_util::future::{FutureExt, LocalBoxFuture};
 use futures_util::StreamExt;

--- a/actix-redis/src/session.rs
+++ b/actix-redis/src/session.rs
@@ -443,7 +443,7 @@ mod test {
         }))
     }
 
-    async fn logout(session: Session) -> Result<HttpResponse> {
+    async fn logout(session: Session) -> Result<actix_web::BaseHttpResponse<actix_web::dev::Body>> {
         let id: Option<String> = session.get("user_id")?;
         if let Some(x) = id {
             session.purge();
@@ -651,7 +651,7 @@ mod test {
             .unwrap();
         assert_ne!(
             OffsetDateTime::now_utc().year(),
-            cookie_4.expires().map(|t| t.year()).unwrap()
+            cookie_4.expires().map(|t| t.datetime().unwrap().year()).unwrap()
         );
 
         // Step 10: GET index, including session cookie #2 in request

--- a/actix-redis/src/session.rs
+++ b/actix-redis/src/session.rs
@@ -3,9 +3,12 @@ use std::{collections::HashMap, iter, rc::Rc};
 use actix::prelude::*;
 use actix_service::{Service, Transform};
 use actix_session::{Session, SessionStatus};
-use actix_web::{HttpRequest, cookie::{Cookie, CookieJar, Key, SameSite}};
 use actix_web::dev::{ServiceRequest, ServiceResponse};
 use actix_web::http::header::{self, HeaderValue};
+use actix_web::{
+    cookie::{Cookie, CookieJar, Key, SameSite},
+    HttpRequest,
+};
 use actix_web::{error, Error};
 use futures_core::future::LocalBoxFuture;
 use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
@@ -157,7 +160,7 @@ where
 
         Box::pin(async move {
             // TODO: replace into_parts() and then from_parts() into a better method of accessing the inner HttpRequest of the ServiceRequest.
-            let (http_req, payload) =  req.into_parts();
+            let (http_req, payload) = req.into_parts();
 
             let state = inner.load(&http_req).await?;
 
@@ -325,8 +328,8 @@ impl Inner {
 
         let state: HashMap<_, _> = state.collect();
 
-
-        let body = serde_json::to_string(&state).map_err(|err| error::JsonPayloadError::Serialize(err))?;
+        let body = serde_json::to_string(&state)
+            .map_err(|err| error::JsonPayloadError::Serialize(err))?;
 
         let cmd = Command(resp_array!["SET", cache_key, body, "EX", &self.ttl]);
 
@@ -443,7 +446,9 @@ mod test {
         }))
     }
 
-    async fn logout(session: Session) -> Result<actix_web::BaseHttpResponse<actix_web::dev::Body>> {
+    async fn logout(
+        session: Session,
+    ) -> Result<actix_web::BaseHttpResponse<actix_web::dev::Body>> {
         let id: Option<String> = session.get("user_id")?;
         if let Some(x) = id {
             session.purge();
@@ -651,7 +656,10 @@ mod test {
             .unwrap();
         assert_ne!(
             OffsetDateTime::now_utc().year(),
-            cookie_4.expires().map(|t| t.datetime().unwrap().year()).unwrap()
+            cookie_4
+                .expires()
+                .map(|t| t.datetime().unwrap().year())
+                .unwrap()
         );
 
         // Step 10: GET index, including session cookie #2 in request

--- a/actix-session/src/cookie.rs
+++ b/actix-session/src/cookie.rs
@@ -529,7 +529,7 @@ mod tests {
         .await;
 
         let request = test::TestRequest::get().to_request();
-        let response = app.call(request).await.unwrap();
+        let response = test::call_service(&app, request).await;
         let expires_1 = response
             .response()
             .cookies()
@@ -540,8 +540,9 @@ mod tests {
 
         actix_rt::time::sleep(std::time::Duration::from_secs(1)).await;
 
+
         let request = test::TestRequest::with_uri("/test/").to_request();
-        let response = app.call(request).await.unwrap();
+        let response = test::call_service(&app, request).await;
         let expires_2 = response
             .response()
             .cookies()
@@ -550,6 +551,6 @@ mod tests {
             .expires()
             .expect("Expiration is set");
 
-        assert!(expires_2 - expires_1 >= Duration::seconds(1));
+        assert!(expires_2.datetime().unwrap() - expires_1.datetime().unwrap() >= Duration::seconds(1));
     }
 }

--- a/actix-session/src/cookie.rs
+++ b/actix-session/src/cookie.rs
@@ -3,16 +3,19 @@
 use std::{collections::HashMap, rc::Rc};
 
 use actix_service::{Service, Transform};
-use actix_web::{HttpRequest, cookie::{Cookie, CookieJar, Key, SameSite}};
 use actix_web::dev::{ServiceRequest, ServiceResponse};
 use actix_web::http::{header::SET_COOKIE, HeaderValue};
-use actix_web::{Error, HttpMessage, ResponseError};
+use actix_web::{
+    cookie::{Cookie, CookieJar, Key, SameSite},
+    HttpRequest,
+};
+use actix_web::{Error, ResponseError};
 use derive_more::Display;
 use futures_util::future::{ok, LocalBoxFuture, Ready};
 use serde_json::error::Error as JsonError;
 use time::{Duration, OffsetDateTime};
 
-use crate::{Session, SessionStatus, UserSession};
+use crate::{Session, SessionStatus};
 
 /// Errors that can occur during handling cookie session
 #[derive(Debug, Display)]
@@ -338,7 +341,7 @@ where
     fn call(&self, mut req: ServiceRequest) -> Self::Future {
         let inner = self.inner.clone();
         // TODO: replace into_parts() and then from_parts() into a better method of accessing the inner HttpRequest of the ServiceRequest.
-        let (http_req, payload) =  req.into_parts();
+        let (http_req, payload) = req.into_parts();
         let (is_new, state) = self.inner.load(&http_req);
         req = ServiceRequest::from_parts(http_req, payload);
         let prolong_expiration = self.inner.expires_in.is_some();
@@ -540,7 +543,6 @@ mod tests {
 
         actix_rt::time::sleep(std::time::Duration::from_secs(1)).await;
 
-
         let request = test::TestRequest::with_uri("/test/").to_request();
         let response = test::call_service(&app, request).await;
         let expires_2 = response
@@ -551,6 +553,9 @@ mod tests {
             .expires()
             .expect("Expiration is set");
 
-        assert!(expires_2.datetime().unwrap() - expires_1.datetime().unwrap() >= Duration::seconds(1));
+        assert!(
+            expires_2.datetime().unwrap() - expires_1.datetime().unwrap()
+                >= Duration::seconds(1)
+        );
     }
 }

--- a/actix-session/src/lib.rs
+++ b/actix-session/src/lib.rs
@@ -49,10 +49,7 @@ use std::{
     rc::Rc,
 };
 
-use actix_web::{
-    dev::{Extensions, Payload, RequestHead, ServiceRequest, ServiceResponse},
-    Error, FromRequest, HttpMessage, HttpRequest,
-};
+use actix_web::{Error, FromRequest, HttpMessage, HttpRequest, dev::{Extensions, Payload, RequestHead, ServiceRequest, ServiceResponse}, error::JsonPayloadError};
 use futures_util::future::{ok, Ready};
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -148,7 +145,7 @@ impl Session {
     /// Get a `value` from the session.
     pub fn get<T: DeserializeOwned>(&self, key: &str) -> Result<Option<T>, Error> {
         if let Some(s) = self.0.borrow().state.get(key) {
-            Ok(Some(serde_json::from_str(s)?))
+            Ok(Some(serde_json::from_str(s).map_err(|err| JsonPayloadError::Serialize(err))?))
         } else {
             Ok(None)
         }
@@ -174,7 +171,7 @@ impl Session {
 
         if inner.status != SessionStatus::Purged {
             inner.status = SessionStatus::Changed;
-            let val = serde_json::to_string(&value)?;
+            let val = serde_json::to_string(&value).map_err(|err| JsonPayloadError::Serialize(err))?;
             inner.state.insert(key.into(), val);
         }
 

--- a/actix-session/src/lib.rs
+++ b/actix-session/src/lib.rs
@@ -49,7 +49,11 @@ use std::{
     rc::Rc,
 };
 
-use actix_web::{Error, FromRequest, HttpMessage, HttpRequest, dev::{Extensions, Payload, RequestHead, ServiceRequest, ServiceResponse}, error::JsonPayloadError};
+use actix_web::{
+    dev::{Extensions, Payload, RequestHead, ServiceRequest, ServiceResponse},
+    error::JsonPayloadError,
+    Error, FromRequest, HttpMessage, HttpRequest,
+};
 use futures_util::future::{ok, Ready};
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -145,7 +149,10 @@ impl Session {
     /// Get a `value` from the session.
     pub fn get<T: DeserializeOwned>(&self, key: &str) -> Result<Option<T>, Error> {
         if let Some(s) = self.0.borrow().state.get(key) {
-            Ok(Some(serde_json::from_str(s).map_err(|err| JsonPayloadError::Serialize(err))?))
+            Ok(Some(
+                serde_json::from_str(s)
+                    .map_err(|err| JsonPayloadError::Serialize(err))?,
+            ))
         } else {
             Ok(None)
         }
@@ -171,7 +178,8 @@ impl Session {
 
         if inner.status != SessionStatus::Purged {
             inner.status = SessionStatus::Changed;
-            let val = serde_json::to_string(&value).map_err(|err| JsonPayloadError::Serialize(err))?;
+            let val = serde_json::to_string(&value)
+                .map_err(|err| JsonPayloadError::Serialize(err))?;
             inner.state.insert(key.into(), val);
         }
 

--- a/actix-web-httpauth/src/extractors/errors.rs
+++ b/actix-web-httpauth/src/extractors/errors.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::fmt;
 
 use actix_web::http::StatusCode;
-use actix_web::{HttpResponse, ResponseError};
+use actix_web::{BaseHttpResponse, ResponseError};
 
 use crate::headers::www_authenticate::Challenge;
 use crate::headers::www_authenticate::WwwAuthenticate;
@@ -51,8 +51,8 @@ impl<C: Challenge> fmt::Display for AuthenticationError<C> {
 impl<C: 'static + Challenge> Error for AuthenticationError<C> {}
 
 impl<C: 'static + Challenge> ResponseError for AuthenticationError<C> {
-    fn error_response(&self) -> HttpResponse {
-        HttpResponse::build(self.status_code)
+    fn error_response(&self) -> BaseHttpResponse<actix_web::dev::Body> {
+        BaseHttpResponse::build(self.status_code)
             // TODO: Get rid of the `.clone()`
             .insert_header(WwwAuthenticate(self.challenge.clone()))
             .finish()


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
Right now all six crates in this repo won't compile because cargo resolves to the new API braking `actix-web-v4.0.0-beta.6` as mentioned [here](https://github.com/actix/actix-extras/issues/176#issue-861069203).

With this patch all sub crates successfully compile with the exception of `actix-identity`,
This is because I didn't find an elegant replacement for the removed API `cookie` from` ServiceRequest`, right now I am using `ServiceRequest::into_parts` and then` ServiceRequest::from_parts` but is a bad workaround. In the `actix -identity` crate it will take a lot of refactoring to apply this workaround (because of the fact that ServiceRequest is passed by ref (as it should)).
Because of that I'll leave this open until [this PR](https://github.com/actix/actix-web/pull/2177#issue-618680142) get merged and then I will be able remove the workaround and fix `actix-identity`.



<!-- If this PR fixes or closes an issue, reference it here. -->
Closes #176
