### PR TITLE
Implement sliding expiration for redis session

### DIFF
--- a/actix-redis/CHANGES.md
+++ b/actix-redis/CHANGES.md
@@ -1,6 +1,7 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
+* Implement `sliding expiration` for redis session
 
 
 ## 0.10.0-beta.2 - 2020-06-27


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Implement **sliding expiration** for redis session
If the `sliding_expiration`  is set true, the time to live in session value will reset after each request.


<!-- If this PR fixes or closes an issue, reference it here. -->
#100
<!-- Closes #000 -->
