### PR TITLE
docs(identity): clarify policy creation

### DIFF
--- a/actix-identity/src/lib.rs
+++ b/actix-identity/src/lib.rs
@@ -33,15 +33,23 @@
 //!     HttpResponse::Ok().finish()
 //! }
 //!
-//! // create cookie identity backend
-//! let policy = CookieIdentityPolicy::new(&[0; 32])
-//!     .name("auth-cookie")
-//!     .secure(false);
+//! #[actix_web::main]
+//! async fn main() -> std::io::Result<()> {
+//!     HttpServer::new(move || {
+//!         // create cookie identity backend
+//!         let policy = CookieIdentityPolicy::new(&[0; 32])
+//!             .name("auth-cookie");
+//!             .secure(false);
 //!
-//! let app = App::new()
-//!     // wrap policy into middleware identity middleware
-//!     .wrap(IdentityService::new(policy))
-//!     .service(services![index, login, logout]);
+//!         App::new()
+//!             // wrap policy into middleware identity middleware
+//!             .wrap(IdentityService::new(policy))
+//!             .service(services![index, login, logout])
+//!     })
+//!     .bind(("0.0.0.0", 8080u16))?
+//!     .run()
+//!     .await
+//! }
 //! ```
 
 #![deny(rust_2018_idioms, nonstandard_style)]

--- a/actix-identity/src/lib.rs
+++ b/actix-identity/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! To access current request identity, use the [`Identity`] extractor.
 //!
-//! ```
+//! ```no_run
 //! use actix_web::*;
 //! use actix_identity::{Identity, CookieIdentityPolicy, IdentityService};
 //!

--- a/actix-identity/src/lib.rs
+++ b/actix-identity/src/lib.rs
@@ -38,7 +38,7 @@
 //!     HttpServer::new(move || {
 //!         // create cookie identity backend
 //!         let policy = CookieIdentityPolicy::new(&[0; 32])
-//!             .name("auth-cookie");
+//!             .name("auth-cookie")
 //!             .secure(false);
 //!
 //!         App::new()


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Other


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Currently, the documentation doesn't clearly show where the `CookieIdentityPolicy` needs to be created.

This PR clarifies that the `CookieIdentityPolicy` is created inside of `HttpServer::new`.

_I'm not sure if I should add a changelog entry since it doesn't change any functionality._

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
Closes #190
