### PR TITLE
relax body bounds

### DIFF
--- a/actix-cors/CHANGES.md
+++ b/actix-cors/CHANGES.md
@@ -1,7 +1,10 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+- Relax body type bounds on middleware impl. [#???]
 - Update `actix-web` dependency to `4.0.0-rc.1`.
+
+[#???]: https://github.com/actix/actix-extras/pull/???
 
 
 ## 0.6.0-beta.8 - 2021-12-29

--- a/actix-cors/CHANGES.md
+++ b/actix-cors/CHANGES.md
@@ -1,10 +1,10 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
-- Relax body type bounds on middleware impl. [#???]
+- Relax body type bounds on middleware impl. [#223]
 - Update `actix-web` dependency to `4.0.0-rc.1`.
 
-[#???]: https://github.com/actix/actix-extras/pull/???
+[#223]: https://github.com/actix/actix-extras/pull/223
 
 
 ## 0.6.0-beta.8 - 2021-12-29

--- a/actix-cors/src/builder.rs
+++ b/actix-cors/src/builder.rs
@@ -490,7 +490,6 @@ where
     S::Future: 'static,
 
     B: MessageBody + 'static,
-    B::Error: Into<Error>,
 {
     type Response = ServiceResponse<EitherBody<B>>;
     type Error = Error;

--- a/actix-cors/src/middleware.rs
+++ b/actix-cors/src/middleware.rs
@@ -143,7 +143,6 @@ where
     S::Future: 'static,
 
     B: MessageBody + 'static,
-    B::Error: Into<Error>,
 {
     type Response = ServiceResponse<EitherBody<B>>;
     type Error = Error;
@@ -189,11 +188,18 @@ where
 mod tests {
     use actix_web::{
         dev::Transform,
+        middleware::Compat,
         test::{self, TestRequest},
+        App,
     };
 
     use super::*;
     use crate::Cors;
+
+    #[test]
+    fn compat_compat() {
+        let _ = App::new().wrap(Compat::new(Cors::default()));
+    }
 
     #[actix_web::test]
     async fn test_options_no_origin() {

--- a/actix-identity/CHANGES.md
+++ b/actix-identity/CHANGES.md
@@ -1,10 +1,10 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
-- Relax body type bounds on middleware impl. [#???]
+- Relax body type bounds on middleware impl. [#223]
 - Update `actix-web` dependency to `4.0.0-rc.1`.
 
-[#???]: https://github.com/actix/actix-extras/pull/???
+[#223]: https://github.com/actix/actix-extras/pull/223
 
 
 ## 0.4.0-beta.8 - 2022-01-21

--- a/actix-identity/CHANGES.md
+++ b/actix-identity/CHANGES.md
@@ -1,7 +1,10 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+- Relax body type bounds on middleware impl. [#???]
 - Update `actix-web` dependency to `4.0.0-rc.1`.
+
+[#???]: https://github.com/actix/actix-extras/pull/???
 
 
 ## 0.4.0-beta.8 - 2022-01-21

--- a/actix-identity/src/middleware.rs
+++ b/actix-identity/src/middleware.rs
@@ -44,7 +44,6 @@ where
     S::Future: 'static,
     T: IdentityPolicy,
     B: MessageBody + 'static,
-    B::Error: Into<Error>,
 {
     type Response = ServiceResponse<EitherBody<B>>;
     type Error = Error;
@@ -80,7 +79,6 @@ where
     S::Future: 'static,
     T: IdentityPolicy,
     B: MessageBody + 'static,
-    B::Error: Into<Error>,
 {
     type Response = ServiceResponse<EitherBody<B>>;
     type Error = Error;

--- a/actix-session/src/cookie.rs
+++ b/actix-session/src/cookie.rs
@@ -301,7 +301,6 @@ where
     S::Future: 'static,
     S::Error: 'static,
     B: MessageBody + 'static,
-    B::Error: Into<Error>,
 {
     type Response = ServiceResponse<EitherBody<B>>;
     type Error = S::Error;
@@ -329,7 +328,6 @@ where
     S::Future: 'static,
     S::Error: 'static,
     B: MessageBody + 'static,
-    B::Error: Into<Error>,
 {
     type Response = ServiceResponse<EitherBody<B>>;
     type Error = S::Error;

--- a/actix-web-httpauth/CHANGES.md
+++ b/actix-web-httpauth/CHANGES.md
@@ -1,10 +1,10 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
-- Relax body type bounds on middleware impl. [#???]
+- Relax body type bounds on middleware impl. [#223]
 - Update `actix-web` dependency to `4.0.0-rc.1`.
 
-[#???]: https://github.com/actix/actix-extras/pull/???
+[#223]: https://github.com/actix/actix-extras/pull/223
 
 
 ## 0.6.0-beta.7 - 2021-12-29

--- a/actix-web-httpauth/CHANGES.md
+++ b/actix-web-httpauth/CHANGES.md
@@ -1,7 +1,10 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+- Relax body type bounds on middleware impl. [#???]
 - Update `actix-web` dependency to `4.0.0-rc.1`.
+
+[#???]: https://github.com/actix/actix-extras/pull/???
 
 
 ## 0.6.0-beta.7 - 2021-12-29

--- a/actix-web-httpauth/src/middleware.rs
+++ b/actix-web-httpauth/src/middleware.rs
@@ -124,7 +124,6 @@ where
     O: Future<Output = Result<ServiceRequest, Error>> + 'static,
     T: AuthExtractor + 'static,
     B: MessageBody + 'static,
-    B::Error: Into<Error>,
 {
     type Response = ServiceResponse<EitherBody<B>>;
     type Error = Error;
@@ -159,7 +158,6 @@ where
     O: Future<Output = Result<ServiceRequest, Error>> + 'static,
     T: AuthExtractor + 'static,
     B: MessageBody + 'static,
-    B::Error: Into<Error>,
 {
     type Response = ServiceResponse<EitherBody<B>>;
     type Error = S::Error;


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Fix


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->

Was causing the following issues with some middleware combinations:
```
error[E0277]: the trait bound `<impl actix_web::body::MessageBody as actix_web::body::MessageBody>::Error: ResponseError` is not satisfied
   --> src/middleware_from_fn.rs:180:23
    |
180 |                 .wrap(Cors::permissive())
    |                  ---- ^^^^^^^^^^^^^^^^^^ the trait `ResponseError` is not implemented for `<impl actix_web::body::MessageBody as actix_web::body::MessageBody>::Error`
    |                  |
    |                  required by a bound introduced by this call
    |
```
