### PR TITLE
[actix-session/redis-rs] Catch server-driven disconnections and prevent a user-visible issue via a retry

### DIFF
--- a/actix-session/CHANGES.md
+++ b/actix-session/CHANGES.md
@@ -4,11 +4,11 @@
 - Implement `SessionExt` for `GuardContext`. [#234]
 - `RedisSessionStore` will prevent connection timeouts from causing user-visible errors. [#235]
 - Do not leak internal implementation details to callers when errors occur. [#236]
- 
+
 [#234]: https://github.com/actix/actix-extras/pull/234
 [#236]: https://github.com/actix/actix-extras/pull/236
-
 [#235]: https://github.com/actix/actix-extras/pull/235
+
 
 ## 0.6.1 - 2022-03-21
 - No significant changes since `0.6.0`.

--- a/actix-session/CHANGES.md
+++ b/actix-session/CHANGES.md
@@ -1,7 +1,10 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+### Fixed
+- `RedisSessionStore` will prevent connection timeouts from causing user-visible errors [#235]
 
+[#235]: https://github.com/actix/actix-extras/pull/235
 
 ## 0.6.0 - 2022-03-15
 ### Added

--- a/actix-session/src/storage/redis_rs.rs
+++ b/actix-session/src/storage/redis_rs.rs
@@ -1,14 +1,12 @@
-use std::sync::Arc;
-
-use redis::{aio::ConnectionManager, AsyncCommands, Value};
-use time::{self, Duration};
-
 use super::SessionKey;
 use crate::storage::{
     interface::{LoadError, SaveError, SessionState, UpdateError},
     utils::generate_session_key,
     SessionStore,
 };
+use redis::{aio::ConnectionManager, Cmd, FromRedisValue, RedisResult, Value};
+use std::sync::Arc;
+use time::{self, Duration};
 
 /// Use Redis as session storage backend.
 ///
@@ -136,10 +134,9 @@ impl RedisSessionStoreBuilder {
 impl SessionStore for RedisSessionStore {
     async fn load(&self, session_key: &SessionKey) -> Result<Option<SessionState>, LoadError> {
         let cache_key = (self.configuration.cache_keygen)(session_key.as_ref());
+
         let value: Option<String> = self
-            .client
-            .clone()
-            .get(cache_key)
+            .execute_command(redis::cmd("GET").arg(&[&cache_key]))
             .await
             .map_err(Into::into)
             .map_err(LoadError::Other)?;
@@ -163,18 +160,16 @@ impl SessionStore for RedisSessionStore {
         let session_key = generate_session_key();
         let cache_key = (self.configuration.cache_keygen)(session_key.as_ref());
 
-        redis::cmd("SET")
-            .arg(&[
-                &cache_key,
-                &body,
-                "NX", // NX: only set the key if it does not already exist
-                "EX", // EX: set expiry
-                &format!("{}", ttl.whole_seconds()),
-            ])
-            .query_async(&mut self.client.clone())
-            .await
-            .map_err(Into::into)
-            .map_err(SaveError::Other)?;
+        self.execute_command(redis::cmd("SET").arg(&[
+            &cache_key,
+            &body,
+            "NX", // NX: only set the key if it does not already exist
+            "EX", // EX: set expiry
+            &format!("{}", ttl.whole_seconds()),
+        ]))
+        .await
+        .map_err(Into::into)
+        .map_err(SaveError::Other)?;
 
         Ok(session_key)
     }
@@ -191,15 +186,14 @@ impl SessionStore for RedisSessionStore {
 
         let cache_key = (self.configuration.cache_keygen)(session_key.as_ref());
 
-        let v: redis::Value = redis::cmd("SET")
-            .arg(&[
+        let v: redis::Value = self
+            .execute_command(redis::cmd("SET").arg(&[
                 &cache_key,
                 &body,
                 "XX", // XX: Only set the key if it already exist.
                 "EX", // EX: set expiry
                 &format!("{}", ttl.whole_seconds()),
-            ])
-            .query_async(&mut self.client.clone())
+            ]))
             .await
             .map_err(Into::into)
             .map_err(UpdateError::Other)?;
@@ -227,15 +221,46 @@ impl SessionStore for RedisSessionStore {
 
     async fn delete(&self, session_key: &SessionKey) -> Result<(), anyhow::Error> {
         let cache_key = (self.configuration.cache_keygen)(session_key.as_ref());
-
-        self.client
-            .clone()
-            .del(&cache_key)
+        self.execute_command(redis::cmd("DEL").arg(&[&cache_key]))
             .await
             .map_err(Into::into)
             .map_err(UpdateError::Other)?;
 
         Ok(())
+    }
+}
+
+impl RedisSessionStore {
+    /// `ConnectionManager` automatically reconnects when it encounters an error talking to Redis.
+    /// The request that bumped into the error, though, fails.
+    ///
+    /// This is generally OK, but there is an unpleasant edge case: Redis client timeouts.
+    /// The server is configured to drop connections who have been active longer than a
+    /// pre-determined threshold.
+    /// `redis-rs` does not proactively detect that the connection has been dropped - you only find
+    /// out when you try to use it.
+    /// This helper method catches this case (`.is_connection_dropped`) to execute a retry.
+    /// The retry will be executed on a fresh connection, therefore it is likely to succeed
+    /// (or fail for a different more meaningful reason).
+    async fn execute_command<T: FromRedisValue>(&self, cmd: &mut Cmd) -> RedisResult<T> {
+        let mut can_retry = true;
+        loop {
+            match cmd.query_async(&mut self.client.clone()).await {
+                Ok(value) => return Ok(value),
+                Err(e) => {
+                    if can_retry && e.is_connection_dropped() {
+                        tracing::debug!(
+                            "Connection dropped while trying to talk to Redis. Retrying."
+                        );
+                        // Retry at most once
+                        can_retry = false;
+                        continue;
+                    } else {
+                        return Err(e);
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #230 

## PR Type
Bug fix

## PR Checklist
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.

This has been tested against the reproducible example provided in #230 - broken before the changes, fixed after.