### PR TITLE
Consistent import formatting

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@ INSERT_PR_TYPE
 - [ ] Tests for the changes have been added / updated.
 - [ ] Documentation comments have been added / updated.
 - [ ] A changelog entry has been made for the appropriate packages.
-- [ ] Format code with the latest stable rustfmt.
+- [ ] Format code with the nightly rustfmt (`cargo +nightly fmt`).
 
 
 ## Overview

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           components: rustfmt
       - name: Check with rustfmt
         uses: actions-rs/cargo@v1

--- a/actix-cors/src/error.rs
+++ b/actix-cors/src/error.rs
@@ -1,5 +1,4 @@
 use actix_web::{http::StatusCode, HttpResponse, ResponseError};
-
 use derive_more::{Display, Error};
 
 /// Errors that can occur when processing CORS guarded requests.

--- a/actix-cors/tests/tests.rs
+++ b/actix-cors/tests/tests.rs
@@ -1,3 +1,4 @@
+use actix_cors::Cors;
 use actix_utils::future::ok;
 use actix_web::dev::fn_service;
 use actix_web::{
@@ -10,8 +11,6 @@ use actix_web::{
     HttpResponse,
 };
 use regex::bytes::Regex;
-
-use actix_cors::Cors;
 
 fn val_as_str(val: &HeaderValue) -> &str {
     val.to_str().unwrap()

--- a/actix-identity/src/cookie.rs
+++ b/actix-identity/src/cookie.rs
@@ -1,9 +1,6 @@
 use std::{rc::Rc, time::SystemTime};
 
 use actix_utils::future::{ready, Ready};
-use serde::{Deserialize, Serialize};
-use time::Duration;
-
 use actix_web::{
     cookie::{Cookie, CookieJar, Key, SameSite},
     dev::{ServiceRequest, ServiceResponse},
@@ -11,6 +8,8 @@ use actix_web::{
     http::header::{self, HeaderValue},
     HttpMessage,
 };
+use serde::{Deserialize, Serialize};
+use time::Duration;
 
 use crate::IdentityPolicy;
 

--- a/actix-protobuf/src/lib.rs
+++ b/actix-protobuf/src/lib.rs
@@ -268,9 +268,10 @@ impl ProtoBufResponseBuilder for HttpResponseBuilder {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use actix_web::http::header;
     use actix_web::test::TestRequest;
+
+    use super::*;
 
     impl PartialEq for ProtoBufPayloadError {
         fn eq(&self, other: &ProtoBufPayloadError) -> bool {

--- a/actix-redis/src/lib.rs
+++ b/actix-redis/src/lib.rs
@@ -4,9 +4,8 @@
 #![warn(future_incompatible)]
 
 mod redis;
-pub use redis::{Command, RedisActor};
-
 use derive_more::{Display, Error, From};
+pub use redis::{Command, RedisActor};
 
 /// General purpose `actix-redis` error.
 #[derive(Debug, Display, Error, From)]

--- a/actix-session/src/storage/mod.rs
+++ b/actix-session/src/storage/mod.rs
@@ -20,9 +20,7 @@ mod utils;
 
 #[cfg(feature = "cookie-session")]
 pub use cookie::CookieSessionStore;
-
 #[cfg(feature = "redis-actor-session")]
 pub use redis_actor::{RedisActorSessionStore, RedisActorSessionStoreBuilder};
-
 #[cfg(feature = "redis-rs-session")]
 pub use redis_rs::{RedisSessionStore, RedisSessionStoreBuilder};

--- a/actix-session/tests/opaque_errors.rs
+++ b/actix-session/tests/opaque_errors.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+use std::convert::TryInto;
+
 use actix_session::storage::{LoadError, SaveError, SessionKey, SessionStore, UpdateError};
 use actix_session::{Session, SessionMiddleware};
 use actix_web::body::MessageBody;
@@ -8,8 +11,6 @@ use actix_web::{
     test, web, App, Responder,
 };
 use anyhow::Error;
-use std::collections::HashMap;
-use std::convert::TryInto;
 
 #[actix_web::test]
 async fn errors_are_opaque() {

--- a/actix-web-httpauth/examples/middleware-closure.rs
+++ b/actix-web-httpauth/examples/middleware-closure.rs
@@ -1,5 +1,4 @@
 use actix_web::{middleware, web, App, HttpServer};
-
 use actix_web_httpauth::middleware::HttpAuthentication;
 
 #[actix_web::main]

--- a/actix-web-httpauth/examples/middleware.rs
+++ b/actix-web-httpauth/examples/middleware.rs
@@ -1,6 +1,5 @@
 use actix_web::dev::ServiceRequest;
 use actix_web::{middleware, web, App, Error, HttpServer};
-
 use actix_web_httpauth::extractors::basic::BasicAuth;
 use actix_web_httpauth::middleware::HttpAuthentication;
 

--- a/actix-web-httpauth/src/extractors/errors.rs
+++ b/actix-web-httpauth/src/extractors/errors.rs
@@ -65,9 +65,10 @@ impl<C: 'static + Challenge> ResponseError for AuthenticationError<C> {
 
 #[cfg(test)]
 mod tests {
+    use actix_web::Error;
+
     use super::*;
     use crate::headers::www_authenticate::basic::Basic;
-    use actix_web::Error;
 
     #[test]
     fn test_status_code_is_preserved_across_error_conversions() {

--- a/actix-web-httpauth/src/middleware.rs
+++ b/actix-web-httpauth/src/middleware.rs
@@ -239,14 +239,15 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::extractors::basic::BasicAuth;
-    use crate::extractors::bearer::BearerAuth;
     use actix_service::{into_service, Service};
     use actix_web::error::ErrorForbidden;
     use actix_web::http::StatusCode;
     use actix_web::test::TestRequest;
     use actix_web::{error, web, App, HttpResponse};
+
+    use super::*;
+    use crate::extractors::basic::BasicAuth;
+    use crate::extractors::bearer::BearerAuth;
 
     /// This is a test for https://github.com/actix/actix-extras/issues/10
     #[actix_web::test]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
 reorder_imports = true
+group_imports = "StdExternalCrate"


### PR DESCRIPTION
## PR Type
Code style

## Overview
Automation to the rescue - this PR configures `rustfmt` to match the import grouping style that you have been enforcing manually in PRs @robjtede.
It requires the nightly toolchain - CI and PR template have been updated accordingly.
