### PR TITLE
Add missing backtic in SessionMiddleware docs

### DIFF
--- a/actix-session/src/middleware.rs
+++ b/actix-session/src/middleware.rs
@@ -29,7 +29,7 @@ use crate::{
 /// To create a new instance of [`SessionMiddleware`] you need to provide:
 ///
 /// - an instance of the session storage backend you wish to use (i.e. an implementation of
-///   [`SessionStore]);
+///   [`SessionStore`]);
 /// - a secret key, to sign or encrypt the content of client-side session cookie.
 ///
 /// ```no_run


### PR DESCRIPTION
Just a quick fix for a doc comment.