### PR TITLE
actix-web-httpauth:  impl Challenge for &str

### DIFF
--- a/actix-web-httpauth/CHANGES.md
+++ b/actix-web-httpauth/CHANGES.md
@@ -1,6 +1,7 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+- impl Challenge for &str
 
 
 ## 0.6.0 - 2022-03-01

--- a/actix-web-httpauth/Cargo.toml
+++ b/actix-web-httpauth/Cargo.toml
@@ -30,3 +30,5 @@ pin-project-lite = "0.2.7"
 [dev-dependencies]
 actix-cors = "0.6.0"
 actix-web = { version = "4", default_features = false, features = ["macros"] }
+proptest = "1.0.0"
+test-strategy = "0.2.0"

--- a/actix-web-httpauth/src/headers/www_authenticate/challenge/mod.rs
+++ b/actix-web-httpauth/src/headers/www_authenticate/challenge/mod.rs
@@ -10,3 +10,27 @@ pub trait Challenge: TryIntoHeaderValue + Debug + Display + Clone + Send + Sync 
     /// Converts the challenge into a bytes suitable for HTTP transmission.
     fn to_bytes(&self) -> Bytes;
 }
+
+/// This is particularly useful for writing constructs such as
+/// `AuthenticationError::new("Authentication required")`
+impl Challenge for &'static str {
+    fn to_bytes(&self) -> Bytes {
+        (*self).into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use test_strategy::proptest;
+
+    use super::*;
+
+    #[proptest]
+    fn roundtrip_static_str(input: Box<str>) {
+        // This will leak, but it's probably fine in the context of a test.  Fixable by adding:
+        //    unsafe { Box::from_raw(s as *const str as *mut str); }
+        let s: &'static str = Box::leak(input);
+        let bytes = s.to_bytes();
+        assert_eq!(s.as_bytes(), bytes);
+    }
+}


### PR DESCRIPTION
## PR Type
Feature

## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x Format code with the nightly rustfmt (`cargo +nightly fmt`).

## Overview
As it stands, using `actix-web-httpauth::middleware::HttpAuthentication` requires creating a type that impls `Challenge` in order to return an `AuthenticationError`.  This makes it possible to simply (e.g.) `return Err(AuthenticationError::new("Authentication required").into())` from your auth check function.