### PR TITLE
bump protobuf to 0.11

### DIFF
--- a/actix-protobuf/CHANGES.md
+++ b/actix-protobuf/CHANGES.md
@@ -2,7 +2,11 @@
 
 ## Unreleased - 2022-xx-xx
 
-
+## 0.8.1 - 2022-08-11
+- Updated `prost` dependency to `0.11`.
+- Updated `future-utils` dependency to remove the patch version.
+- Updated `derive_more` dependency to remove the patch version.
+- Added `application/x-protobuf` as an acceptable header.
 ## 0.8.0 - 2022-06-25
 - Update `prost` dependency to `0.10`.
 - Minimum supported Rust version (MSRV) is now 1.57 due to transitive `time` dependency.

--- a/actix-protobuf/Cargo.toml
+++ b/actix-protobuf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-protobuf"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2018"
 authors = [
     "kingxsp <jin.hb.zh@outlook.com>",

--- a/actix-protobuf/Cargo.toml
+++ b/actix-protobuf/Cargo.toml
@@ -20,8 +20,9 @@ path = "src/lib.rs"
 actix-web = { version = "4", default_features = false }
 derive_more = "0.99.5"
 futures-util = { version = "0.3.7", default-features = false }
-prost = { version = "0.10", default_features = false }
+prost = { version = "0.11.0", default_features = false }
+log = "0.4.17"
 
 [dev-dependencies]
 actix-web = { version = "4", default_features = false, features = ["macros"] }
-prost = { version = "0.10", default_features = false, features = ["prost-derive"] }
+prost = { version = "0.11.0", default_features = false, features = ["prost-derive"] }

--- a/actix-protobuf/Cargo.toml
+++ b/actix-protobuf/Cargo.toml
@@ -18,10 +18,9 @@ path = "src/lib.rs"
 
 [dependencies]
 actix-web = { version = "4", default_features = false }
-derive_more = "0.99.5"
-futures-util = { version = "0.3.7", default-features = false }
-prost = { version = "0.11.0", default_features = false }
-log = "0.4.17"
+derive_more = "0.99"
+futures-util = { version = "0.3", default-features = false }
+prost = { version = "0.11", default_features = false }
 
 [dev-dependencies]
 actix-web = { version = "4", default_features = false, features = ["macros"] }

--- a/actix-protobuf/Cargo.toml
+++ b/actix-protobuf/Cargo.toml
@@ -24,4 +24,4 @@ prost = { version = "0.11", default_features = false }
 
 [dev-dependencies]
 actix-web = { version = "4", default_features = false, features = ["macros"] }
-prost = { version = "0.11.0", default_features = false, features = ["prost-derive"] }
+prost = { version = "0.11", default_features = false, features = ["prost-derive"] }

--- a/actix-protobuf/src/lib.rs
+++ b/actix-protobuf/src/lib.rs
@@ -172,9 +172,9 @@ pub struct ProtoBufMessage<T: Message + Default> {
 impl<T: Message + Default> ProtoBufMessage<T> {
     /// Create `ProtoBufMessage` for request.
     pub fn new(req: &HttpRequest, payload: &mut Payload) -> Self {
-      if    req.content_type() != "application/protobuf" &&
-	        req.content_type() != "application/x-protobuf"
-	{
+        if req.content_type() != "application/protobuf"
+            && req.content_type() != "application/x-protobuf"
+        {
             return ProtoBufMessage {
                 limit: 262_144,
                 length: None,

--- a/actix-protobuf/src/lib.rs
+++ b/actix-protobuf/src/lib.rs
@@ -172,7 +172,9 @@ pub struct ProtoBufMessage<T: Message + Default> {
 impl<T: Message + Default> ProtoBufMessage<T> {
     /// Create `ProtoBufMessage` for request.
     pub fn new(req: &HttpRequest, payload: &mut Payload) -> Self {
-        if req.content_type() != "application/protobuf" {
+      if    req.content_type() != "application/protobuf" &&
+	        req.content_type() != "application/x-protobuf"
+	{
             return ProtoBufMessage {
                 limit: 262_144,
                 length: None,


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
Primary change is for the server to accept application/x-protobuf in addition to
application/protobuf as many clients do tend to send the other mime-type.

<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix - Not really a bug-fix (but sorta)
Other - updated dependencies' versions


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [X] A changelog entry has been made for the appropriate packages.
- [X] Format code with the nightly rustfmt (`cargo +nightly fmt`).


## Overview
<!-- Describe the current and new behavior. -->
* actix-protobuf now accepts application/x-protobuf
* Upgrading to prost 0.11 in actix-protobuf prepares for better 
refactoring down the line

<!-- Emphasize any breaking changes. -->
<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
