### PR TITLE
Add note for accessing session state in stream.

### DIFF
--- a/actix-session/src/lib.rs
+++ b/actix-session/src/lib.rs
@@ -65,7 +65,7 @@
 //! ```
 //!
 //! The session state can be accessed and modified by your request handlers using the [`Session`]
-//! extractor.
+//! extractor. Note that this doesn't work in the stream of a streaming response.
 //!
 //! ```no_run
 //! use actix_web::Error;


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Small documentation improvement.


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the nightly rustfmt (`cargo +nightly fmt`).


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
I found out that you can't even read the session state in a stream of a streaming response. This may be unintentional behaviour as I think reading could be possible just not writing as the headers have already been sent. In any case I think it may be helpful to document this.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
