### PR TITLE
Add block_on_origin_mismatch option to middleware

### DIFF
--- a/actix-cors/CHANGES.md
+++ b/actix-cors/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased - 2022-xx-xx
 - Minimum supported Rust version (MSRV) is now 1.59 due to transitive `time` dependency.
+- Add `block_on_origin_mismatch` option to actix-cors [#286]
 
 
 ## 0.6.2 - 2022-08-07

--- a/actix-cors/CHANGES.md
+++ b/actix-cors/CHANGES.md
@@ -2,7 +2,9 @@
 
 ## Unreleased - 2022-xx-xx
 - Minimum supported Rust version (MSRV) is now 1.59 due to transitive `time` dependency.
-- Add `block_on_origin_mismatch` option to actix-cors [#286]
+- Add `Cors::block_on_origin_mismatch()` option for controlling if requests are pre-emptively rejected. [#286]
+
+[#286]: https://github.com/actix/actix-extras/pull/286
 
 
 ## 0.6.2 - 2022-08-07

--- a/actix-cors/examples/cors.rs
+++ b/actix-cors/examples/cors.rs
@@ -39,6 +39,8 @@ async fn main() -> std::io::Result<()> {
                     .allowed_header(header::CONTENT_TYPE)
                     // set list of headers that are safe to expose
                     .expose_headers(&[header::CONTENT_DISPOSITION])
+                    // allow cURL/HTTPie from working without providing Origin headers
+                    .block_on_origin_mismatch(false)
                     // set preflight cache TTL
                     .max_age(3600),
             )

--- a/actix-cors/src/builder.rs
+++ b/actix-cors/src/builder.rs
@@ -458,9 +458,9 @@ impl Cors {
     /// If `false`, actix-cors won't do anything extra regarding allow requests or
     /// not and simply add the needed headers to work with CORS in browsers.
     ///
-    /// With the false set to `false`, it is up to the browser to validate CORS headers
+    /// With the option set to `false`, it is up to the browser to validate CORS headers
     /// and block requests. Other HTTP-aware tools like cURL will still function
-    /// as normal, no matter what Origin you send.
+    /// as normal, no matter what Origin the request has.
     ///
     /// Defaults to `true`.
     ///

--- a/actix-cors/src/builder.rs
+++ b/actix-cors/src/builder.rs
@@ -102,6 +102,7 @@ impl Cors {
             send_wildcard: false,
             supports_credentials: true,
             vary_header: true,
+            block_on_origin_mismatch: true,
         };
 
         Cors {
@@ -448,6 +449,28 @@ impl Cors {
 
         self
     }
+
+    /// Decides if actix-cors should explicitly block requests with mismatches Origin or not
+    ///
+    /// If `true`, actix-cors will return 400 Bad Request if the Origin header from
+    /// the request doesn't match the list of valid Origins.
+    ///
+    /// If `false`, actix-cors won't do anything extra regarding allow requests or
+    /// not and simply add the needed headers to work with CORS in browsers.
+    ///
+    /// With the false set to `false`, it is up to the browser to validate CORS headers
+    /// and block requests. Other HTTP-aware tools like cURL will still function
+    /// as normal, no matter what Origin you send.
+    ///
+    /// Defaults to `true`.
+    ///
+    pub fn block_on_origin_mismatch(mut self, val: bool) -> Cors {
+        if let Some(cors) = cors(&mut self.inner, &self.error) {
+            cors.block_on_origin_mismatch = val
+        }
+
+        self
+    }
 }
 
 impl Default for Cors {
@@ -474,6 +497,7 @@ impl Default for Cors {
             send_wildcard: false,
             supports_credentials: false,
             vary_header: true,
+            block_on_origin_mismatch: true,
         };
 
         Cors {

--- a/actix-cors/src/builder.rs
+++ b/actix-cors/src/builder.rs
@@ -450,23 +450,19 @@ impl Cors {
         self
     }
 
-    /// Decides if actix-cors should explicitly block requests with mismatches Origin or not
+    /// Configures whether requests should be pre-emptively blocked on mismatched origin.
     ///
-    /// If `true`, actix-cors will return 400 Bad Request if the Origin header from
-    /// the request doesn't match the list of valid Origins.
+    /// If `true`, a 400 Bad Request is returned immediately when a request fails origin validation.
     ///
-    /// If `false`, actix-cors won't do anything extra regarding allow requests or
-    /// not and simply add the needed headers to work with CORS in browsers.
-    ///
-    /// With the option set to `false`, it is up to the browser to validate CORS headers
-    /// and block requests. Other HTTP-aware tools like cURL will still function
-    /// as normal, no matter what Origin the request has.
+    /// If `false`, the request will be processed as normal but relevant CORS headers will not be
+    /// appended to the response. In this case, the browser is trusted to validate CORS headers and
+    /// and block requests based on pre-flight requests. Use this setting to allow cURL and other
+    /// non-browser HTTP clients to function as normal, no matter what `Origin` the request has.
     ///
     /// Defaults to `true`.
-    ///
-    pub fn block_on_origin_mismatch(mut self, val: bool) -> Cors {
+    pub fn block_on_origin_mismatch(mut self, block: bool) -> Cors {
         if let Some(cors) = cors(&mut self.inner, &self.error) {
-            cors.block_on_origin_mismatch = val
+            cors.block_on_origin_mismatch = block
         }
 
         self

--- a/actix-cors/tests/tests.rs
+++ b/actix-cors/tests/tests.rs
@@ -385,10 +385,18 @@ async fn test_mismatched_origin_block_turned_off() {
         .await
         .unwrap();
 
-    let req = TestRequest::get()
-        .insert_header(("Origin", "https://www.example.test"))
+    let req = TestRequest::default()
+        .method(Method::OPTIONS)
+        .insert_header(("Origin", "https://wrong.com"))
+        .insert_header(("Access-Control-Request-Method", "POST"))
         .to_srv_request();
+    let res = test::call_service(&cors, req).await;
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(res.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN), None);
 
+    let req = TestRequest::get()
+        .insert_header(("Origin", "https://wrong.com"))
+        .to_srv_request();
     let res = test::call_service(&cors, req).await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(res.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN), None);

--- a/actix-cors/tests/tests.rs
+++ b/actix-cors/tests/tests.rs
@@ -366,13 +366,19 @@ async fn test_blocks_mismatched_origin_by_default() {
         .insert_header(("Origin", "https://www.example.test"))
         .to_srv_request();
 
-    let resp = test::call_service(&cors, req).await;
-    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let res = test::call_service(&cors, req).await;
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(res.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN), None);
+    assert!(res
+        .headers()
+        .get(header::ACCESS_CONTROL_ALLOW_METHODS)
+        .is_none());
 }
 
 #[actix_web::test]
 async fn test_mismatched_origin_block_turned_off() {
     let cors = Cors::default()
+        .allow_any_method()
         .allowed_origin("https://www.example.com")
         .block_on_origin_mismatch(false)
         .new_transform(test::ok_service())
@@ -383,8 +389,9 @@ async fn test_mismatched_origin_block_turned_off() {
         .insert_header(("Origin", "https://www.example.test"))
         .to_srv_request();
 
-    let resp = test::call_service(&cors, req).await;
-    assert_eq!(resp.status(), StatusCode::OK);
+    let res = test::call_service(&cors, req).await;
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN), None);
 }
 
 #[actix_web::test]


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [X] A changelog entry has been made for the appropriate packages.
- [X] Format code with the nightly rustfmt (`cargo +nightly fmt`).


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

Retains current behavior, adds a new option to get the behaviour described in the issue, where it will be up to browsers to handle if the request should be allowed or not, allowing other tools like cURL (who don't care about Origin) to continue to work regardless of CORS headers. 

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->

Closes #286
