### PR TITLE
[LIMITATION] Feature: allow multiple Limiters with different configurations

### DIFF
--- a/actix-limitation/src/builder.rs
+++ b/actix-limitation/src/builder.rs
@@ -7,10 +7,19 @@ use redis::Client;
 
 use crate::{errors::Error, GetArcBoxKeyFn, Limiter};
 
+/// [RedisConnectionKind] is used to define which connection parameter for the Redis server will be passed
+/// It can be an Url or a Client
+/// This is done so we can use the same client for multiple Limiters
+#[derive(Debug, Clone)]
+pub enum RedisConnectionKind {
+    Url(String),
+    Client(Client),
+}
+
 /// Rate limiter builder.
 #[derive(Debug)]
 pub struct Builder {
-    pub(crate) redis_url: String,
+    pub(crate) redis_connection: RedisConnectionKind,
     pub(crate) limit: usize,
     pub(crate) period: Duration,
     pub(crate) get_key_fn: Option<GetArcBoxKeyFn>,
@@ -96,8 +105,12 @@ impl Builder {
             closure
         };
 
+        let client = match &self.redis_connection {
+            RedisConnectionKind::Url(url) => Client::open(url.as_str())?,
+            RedisConnectionKind::Client(client) => client.clone(),
+        };
         Ok(Limiter {
-            client: Client::open(self.redis_url.as_str())?,
+            client,
             limit: self.limit,
             period: self.period,
             get_key_fn: get_key,
@@ -109,12 +122,25 @@ impl Builder {
 mod tests {
     use super::*;
 
+    /// Implementing partial Eq to check if builder assigned the redis connection url correctly
+    /// We can't / shouldn't compare Redis clients, thus the method panic if we try to compare them
+    impl PartialEq for RedisConnectionKind {
+        fn eq(&self, other: &Self) -> bool {
+            match (self, other) {
+                (Self::Url(l_url), Self::Url(r_url)) => l_url == r_url,
+                _ => {
+                    panic!("RedisConnectionKind PartialEq is only implemented for Url")
+                }
+            }
+        }
+    }
+
     #[test]
     fn test_create_builder() {
-        let redis_url = "redis://127.0.0.1";
+        let redis_connection = RedisConnectionKind::Url("redis://127.0.0.1".to_string());
         let period = Duration::from_secs(10);
         let builder = Builder {
-            redis_url: redis_url.to_owned(),
+            redis_connection: redis_connection.clone(),
             limit: 100,
             period,
             get_key_fn: Some(Arc::new(|_| None)),
@@ -123,7 +149,7 @@ mod tests {
             session_key: Cow::Owned("rate-api".to_string()),
         };
 
-        assert_eq!(builder.redis_url, redis_url);
+        assert_eq!(builder.redis_connection, redis_connection);
         assert_eq!(builder.limit, 100);
         assert_eq!(builder.period, period);
         #[cfg(feature = "session")]
@@ -133,10 +159,10 @@ mod tests {
 
     #[test]
     fn test_create_limiter() {
-        let redis_url = "redis://127.0.0.1";
+        let redis_connection = RedisConnectionKind::Url("redis://127.0.0.1".to_string());
         let period = Duration::from_secs(20);
         let mut builder = Builder {
-            redis_url: redis_url.to_owned(),
+            redis_connection,
             limit: 100,
             period: Duration::from_secs(10),
             get_key_fn: Some(Arc::new(|_| None)),
@@ -154,10 +180,10 @@ mod tests {
     #[test]
     #[should_panic = "Redis URL did not parse"]
     fn test_create_limiter_error() {
-        let redis_url = "127.0.0.1";
+        let redis_connection = RedisConnectionKind::Url("127.0.0.1".to_string());
         let period = Duration::from_secs(20);
         let mut builder = Builder {
-            redis_url: redis_url.to_owned(),
+            redis_connection,
             limit: 100,
             period: Duration::from_secs(10),
             get_key_fn: Some(Arc::new(|_| None)),

--- a/actix-limitation/src/lib.rs
+++ b/actix-limitation/src/lib.rs
@@ -7,7 +7,7 @@
 //! ```
 //!
 //! ```no_run
-//! use std::{sync::Arc, time::Duration};
+//! use std::{time::Duration};
 //! use actix_web::{dev::ServiceRequest, get, web, App, HttpServer, Responder};
 //! use actix_session::SessionExt as _;
 //! use actix_limitation::{Limiter, RateLimiter};
@@ -23,8 +23,8 @@
 //!         Limiter::builder("redis://127.0.0.1")
 //!             .key_by(|req: &ServiceRequest| {
 //!                 req.get_session()
-//!                     .get(&"session-id")
-//!                     .unwrap_or_else(|_| req.cookie(&"rate-api-id").map(|c| c.to_string()))
+//!                     .get("session-id")
+//!                     .unwrap_or_else(|_| req.cookie("rate-api-id").map(|c| c.to_string()))
 //!             })
 //!             .limit(5000)
 //!             .period(Duration::from_secs(3600)) // 60 minutes
@@ -175,5 +175,42 @@ mod tests {
         let limiter = limiter.unwrap();
         assert_eq!(limiter.limit, 5000);
         assert_eq!(limiter.period, Duration::from_secs(3600));
+    }
+
+    #[actix_web::test]
+    async fn test_create_scoped_limiter() {
+        todo!("finish tests")
+        // use actix_session::SessionExt as _;
+        // use actix_web::{dev::ServiceRequest, get, web, App, HttpServer, Responder};
+        // use std::time::Duration;
+
+        // #[get("/{id}/{name}")]
+        // async fn index(info: web::Path<(u32, String)>) -> impl Responder {
+        //     format!("Hello {}! id:{}", info.1, info.0)
+        // }
+
+        // let limiter = web::Data::new(
+        //     Limiter::builder("redis://127.0.0.1")
+        //         .key_by(|req: &ServiceRequest| {
+        //             req.get_session()
+        //                 .get("session-id")
+        //                 .unwrap_or_else(|_| req.cookie("rate-api-id").map(|c| c.to_string()))
+        //         })
+        //         .limit(5000)
+        //         .period(Duration::from_secs(3600)) // 60 minutes
+        //         .build()
+        //         .unwrap(),
+        // );
+
+        // HttpServer::new(move || {
+        //     App::new()
+        //         .wrap(RateLimiter::default())
+        //         .app_data(limiter.clone())
+        //         .service(index)
+        // })
+        // .bind(("127.0.0.1", 8080))
+        // .expect("test")
+        // .run()
+        // .await;
     }
 }

--- a/actix-limitation/src/middleware.rs
+++ b/actix-limitation/src/middleware.rs
@@ -73,11 +73,11 @@ where
                 .unwrap_or_else(|| panic!("Unable to find defined limiter with scope: {}", scope))
                 .clone()
         } else {
-            let a = req
+            let limiter = req
                 .app_data::<web::Data<Limiter>>()
                 .expect("web::Data<Limiter> should be set in app data for RateLimiter middleware");
             // Deref to get the Limiter
-            (***a).clone()
+            (***limiter).clone()
         };
 
         let key = (limiter.get_key_fn)(&req);


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the nightly rustfmt (`cargo +nightly fmt`).


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Currently I can declare and use only one Limiter who can hold one configuration
This PR adds the possibility to create a multitude of Limiter so we can have different configurations

## Notes
I added a method to build the Limiter with an already existing Client (`builder_with_redis_client`) to prevent re-creating a new client for each new Limiter
I don't actually know if this was a good idea and is making any performance improvements. And I didn't have the time to test it