### PR TITLE
Fix GHA deprecation warnings

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           command: generate-lockfile
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1.2.0
+        uses: Swatinem/rust-cache@v2.1.0
 
       - name: check minimal
         uses: actions-rs/cargo@v1
@@ -72,7 +72,11 @@ jobs:
       matrix:
         target:
           - { name: macOS, os: macos-latest, triple: x86_64-apple-darwin }
-          - { name: Windows, os: windows-latest, triple: x86_64-pc-windows-msvc }
+          - {
+              name: Windows,
+              os: windows-latest,
+              triple: x86_64-pc-windows-msvc,
+            }
         version:
           - nightly
 
@@ -83,44 +87,30 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install ${{ matrix.version }}
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.version }}-${{ matrix.target.triple }}
-          profile: minimal
-          override: true
+        run: |
+          rustup install ${{ matrix.version }}-${{ matrix.target.triple }}
+          rustup override set ${{ matrix.version }}-${{ matrix.target.triple }}
 
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
 
       - name: Generate Cargo.lock
-        uses: actions-rs/cargo@v1
-        with:
-          command: generate-lockfile
+        run: cargo generate-lockfile
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1.2.0
+        uses: Swatinem/rust-cache@v2.1.0
 
       - name: check minimal
-        uses: actions-rs/cargo@v1
-        with: { command: ci-min }
+        run: cargo ci-min
 
       - name: check minimal + examples
-        uses: actions-rs/cargo@v1
-        with: { command: ci-check-min-examples }
+        run: cargo ci-check-min-examples
 
       - name: check default
-        uses: actions-rs/cargo@v1
-        with: { command: ci-check }
+        run: cargo ci-check
 
       - name: tests
-        uses: actions-rs/cargo@v1
         timeout-minutes: 40
-        with:
-          command: ci-test
-          args: >-
-            --exclude=actix-redis
-            --exclude=actix-session
-            --exclude=actix-limitation
-            -- --nocapture
+        run: cargo ci-test --exclude=actix-redis --exclude=actix-session --exclude=actix-limitation -- --nocapture
 
       - name: Clear the cargo caches
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,38 +36,30 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install ${{ matrix.version }}
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.version }}-${{ matrix.target.triple }}
-          profile: minimal
-          override: true
+        run: |
+          rustup install ${{ matrix.version }}-${{ matrix.target.triple }}
+          rustup override set ${{ matrix.version }}-${{ matrix.target.triple }}
 
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
 
       - name: Generate Cargo.lock
-        uses: actions-rs/cargo@v1
-        with:
-          command: generate-lockfile
+        run: cargo generate-lockfile
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1.2.0
+        uses: Swatinem/rust-cache@v2.1.0
 
       - name: check minimal
-        uses: actions-rs/cargo@v1
-        with: { command: ci-min }
+        run: cargo ci-min
 
       - name: check minimal + examples
-        uses: actions-rs/cargo@v1
-        with: { command: ci-check-min-examples }
+        run: cargo ci-check-min-examples
 
       - name: check default
-        uses: actions-rs/cargo@v1
-        with: { command: ci-check }
+        run: cargo ci-check
 
       - name: tests
-        uses: actions-rs/cargo@v1
         timeout-minutes: 40
-        with: { command: ci-test }
+        run: cargo ci-test
 
       - name: Clear the cargo caches
         run: |
@@ -80,7 +72,11 @@ jobs:
       matrix:
         target:
           - { name: macOS, os: macos-latest, triple: x86_64-apple-darwin }
-          - { name: Windows, os: windows-latest, triple: x86_64-pc-windows-msvc }
+          - {
+              name: Windows,
+              os: windows-latest,
+              triple: x86_64-pc-windows-msvc,
+            }
         version:
           - 1.59 # MSRV
           - stable
@@ -92,43 +88,30 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install ${{ matrix.version }}
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.version }}-${{ matrix.target.triple }}
-          profile: minimal
-          override: true
+        run: |
+          rustup install ${{ matrix.version }}-${{ matrix.target.triple }}
+          rustup override set ${{ matrix.version }}-${{ matrix.target.triple }}
 
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
 
       - name: Generate Cargo.lock
-        uses: actions-rs/cargo@v1
-        with:
-          command: generate-lockfile
+        run: cargo generate-lockfile
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1.2.0
+        uses: Swatinem/rust-cache@v2.1.0
 
       - name: check minimal
-        uses: actions-rs/cargo@v1
-        with: { command: ci-min }
+        run: cargo ci-min
 
       - name: check minimal + examples
-        uses: actions-rs/cargo@v1
-        with: { command: ci-check-min-examples }
+        run: cargo ci-check-min-examples
 
       - name: check default
-        uses: actions-rs/cargo@v1
-        with: { command: ci-check }
+        run: cargo ci-check
 
       - name: tests
-        uses: actions-rs/cargo@v1
         timeout-minutes: 40
-        with:
-          command: ci-test
-          args: >-
-            --exclude=actix-redis
-            --exclude=actix-session
-            --exclude=actix-limitation
+        run: cargo ci-test --exclude=actix-redis --exclude=actix-session --exclude=actix-limitation
 
       - name: Clear the cargo caches
         run: |
@@ -142,21 +125,15 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Rust (nightly)
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-x86_64-unknown-linux-gnu
-          profile: minimal
-          override: true
+        run: |
+          rustup install nightly
+          rustup override set nightly
 
       - name: Generate Cargo.lock
-        uses: actions-rs/cargo@v1
-        with: { command: generate-lockfile }
+        run: cargo generate-lockfile
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1.3.0
+        uses: Swatinem/rust-cache@v2.1.0
 
       - name: doc tests
-        uses: actions-rs/cargo@v1
         timeout-minutes: 40
-        with:
-          command: ci-doctest
-          args: -- --nocapture
+        run: cargo ci-doctest -- --nocapture

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,22 +21,19 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install stable
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable-x86_64-unknown-linux-gnu
-          profile: minimal
-          override: true
+        run: |
+          rustup override set stable
+          rustup update stable
 
       - name: Generate Cargo.lock
-        uses: actions-rs/cargo@v1
-        with: { command: generate-lockfile }
+        run: cargo generate-lockfile
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1.2.0
+        uses: Swatinem/rust-cache@v2.1.0
 
       - name: Generate coverage file
         run: |
           cargo install cargo-tarpaulin --vers "^0.13"
           cargo tarpaulin --workspace --out Xml --verbose
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with: { file: cobertura.xml }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,15 +11,12 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          components: rustfmt
+        run: |
+          rustup override set nightly
+          rustup update nightly
+          rustup component add rustfmt
       - name: Check with rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
   clippy:
     runs-on: ubuntu-latest
@@ -27,13 +24,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: clippy
-          override: true
+        run: |
+          rustup override set stable
+          rustup update stable
+          rustup component add rustfmt
       - name: Check with Clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --workspace --tests --all-features
+        run: cargo clippy --workspace --tests --all-features

--- a/.github/workflows/upload-doc.yml
+++ b/.github/workflows/upload-doc.yml
@@ -12,17 +12,12 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-x86_64-unknown-linux-gnu
-          profile: minimal
-          override: true
+        run: |
+          rustup override set nightly
+          rustup update nightly
 
       - name: Build Docs
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --workspace --all-features --no-deps
+        run: cargo doc --workspace --all-features --no-deps
 
       - name: Tweak HTML
         run: echo '<meta http-equiv="refresh" content="0;url=actix_cors/index.html">' > target/doc/index.html


### PR DESCRIPTION
Signed-off-by: Yuki Okushi <jtitor@2k36.org>

<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Other


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the nightly rustfmt (`cargo +nightly fmt`).


## Overview

actions-rs is now unmaintained: https://togithub.com/actions-rs/toolchain/issues/216
That produces a bunch of GHA warnings that mean workflows will stop by next year if there's no action, see https://github.com/actix/actix-extras/actions/runs/3418094869 for example.
This just replaces them with plain commands. Alternatively, we could use https://github.com/dtolnay/rust-toolchain, but I'm not sure if it makes a huge benefit (I remember GHA doesn't play with rustup self-update on some runners in the past, but I'm not sure if it still occurs, let's check).
