### PR TITLE
Feat: extract session key

### DIFF
--- a/actix-session/Cargo.toml
+++ b/actix-session/Cargo.toml
@@ -41,6 +41,7 @@ tracing = { version = "0.1.30", default-features = false, features = ["log"] }
 actix = { version = "0.13", default-features = false, optional = true }
 actix-redis = { version = "0.12", optional = true }
 futures-core = { version = "0.3.7", default-features = false, optional = true }
+secrecy = "0.8"
 
 # redis-rs-session
 redis = { version = "0.22", default-features = false, features = ["tokio-comp", "connection-manager"], optional = true }

--- a/actix-session/src/middleware.rs
+++ b/actix-session/src/middleware.rs
@@ -218,7 +218,7 @@ where
             let (session_key, session_state) =
                 load_session_state(session_key, storage_backend.as_ref()).await?;
 
-            Session::set_session(&mut req, session_state);
+            Session::set_session(&mut req, session_state, session_key.clone());
 
             let mut res = service.call(req).await?;
             let (status, session_state) = Session::get_changes(&mut res);

--- a/actix-session/src/session.rs
+++ b/actix-session/src/session.rs
@@ -17,6 +17,8 @@ use anyhow::Context;
 use derive_more::{Display, From};
 use serde::{de::DeserializeOwned, Serialize};
 
+use crate::storage::SessionKey;
+
 /// The primary interface to access and modify session state.
 ///
 /// [`Session`] is an [extractor](#impl-FromRequest)—you can specify it as an input type for your
@@ -77,6 +79,7 @@ impl Default for SessionStatus {
 struct SessionInner {
     state: HashMap<String, String>,
     status: SessionStatus,
+    session_key: Option<SessionKey>,
 }
 
 impl Session {
@@ -101,7 +104,15 @@ impl Session {
             Ok(None)
         }
     }
-
+    /// Get a the session key itself from the overall session.
+    ///
+    /// Retrieve the overall session key
+    pub fn get_session_key(&self) -> secrecy::Secret<SessionKey> {
+        todo!("either grab the key or figure out how to populate InnerSession session_key field");
+        // let key = Session::set_session(&mut self.0., self.0);
+        let key = self.0.borrow().session_key.clone(); //
+        secrecy::Secret::new(key.unwrap())
+    }
     /// Get all raw key-value data from the session.
     ///
     /// Note that values are JSON encoded.

--- a/actix-session/src/session.rs
+++ b/actix-session/src/session.rs
@@ -107,12 +107,10 @@ impl Session {
     /// Get a the session key itself from the overall session.
     ///
     /// Retrieve the overall session key
-    pub fn get_session_key(&self) -> secrecy::Secret<SessionKey> {
-        todo!("either grab the key or figure out how to populate InnerSession session_key field");
-        // let key = Session::set_session(&mut self.0., self.0);
-        let key = self.0.borrow().session_key.clone(); //
-        secrecy::Secret::new(key.unwrap())
+    pub fn get_session_key(&self) -> Option<SessionKey> {
+        self.0.borrow().session_key.clone()
     }
+
     /// Get all raw key-value data from the session.
     ///
     /// Note that values are JSON encoded.
@@ -232,10 +230,12 @@ impl Session {
     pub(crate) fn set_session(
         req: &mut ServiceRequest,
         data: impl IntoIterator<Item = (String, String)>,
+        session_key: Option<SessionKey>,
     ) {
         let session = Session::get_session(&mut req.extensions_mut());
         let mut inner = session.0.borrow_mut();
         inner.state.extend(data);
+        inner.session_key = session_key;
     }
 
     /// Returns session status and iterator of key-value pairs of changes.

--- a/actix-session/src/storage/cookie.rs
+++ b/actix-session/src/storage/cookie.rs
@@ -2,6 +2,7 @@ use std::convert::TryInto;
 
 use actix_web::cookie::time::Duration;
 use anyhow::Error;
+use secrecy::ExposeSecret;
 
 use super::SessionKey;
 use crate::storage::{
@@ -54,7 +55,7 @@ pub struct CookieSessionStore;
 #[async_trait::async_trait(?Send)]
 impl SessionStore for CookieSessionStore {
     async fn load(&self, session_key: &SessionKey) -> Result<Option<SessionState>, LoadError> {
-        serde_json::from_str(session_key.as_ref())
+        serde_json::from_str(session_key.as_ref().expose_secret())
             .map(Some)
             .map_err(anyhow::Error::new)
             .map_err(LoadError::Deserialization)

--- a/actix-session/src/storage/session_key.rs
+++ b/actix-session/src/storage/session_key.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 
 use derive_more::{Display, From};
-use secrecy::Secret;
+use secrecy::{ExposeSecret, Secret};
 
 /// A session key, the string stored in a client-side cookie to associate a user with its session
 /// state on the backend.
@@ -21,6 +21,13 @@ use secrecy::Secret;
 #[derive(Debug, Clone)]
 pub struct SessionKey(secrecy::Secret<String>);
 
+impl SessionKey {
+    /// Convert the SessionKey into the inner Secret
+    pub fn into_inner(self) -> secrecy::Secret<String> {
+        self.0
+    }
+}
+
 impl TryFrom<String> for SessionKey {
     type Error = InvalidSessionKeyError;
 
@@ -31,8 +38,7 @@ impl TryFrom<String> for SessionKey {
             )
             .into());
         }
-        let val_secret = Secret::new(val);
-        Ok(SessionKey(val_secret))
+        Ok(SessionKey(Secret::new(val)))
     }
 }
 
@@ -42,15 +48,9 @@ impl AsRef<secrecy::Secret<String>> for SessionKey {
     }
 }
 
-impl secrecy::Zeroize for SessionKey {
-    fn zeroize(&mut self) {
-        self.0.zeroize();
-    }
-}
-
 impl From<SessionKey> for String {
     fn from(key: SessionKey) -> Self {
-        key.0
+        key.0.expose_secret().into()
     }
 }
 

--- a/actix-session/src/storage/session_key.rs
+++ b/actix-session/src/storage/session_key.rs
@@ -1,6 +1,7 @@
 use std::convert::TryFrom;
 
 use derive_more::{Display, From};
+use secrecy::Secret;
 
 /// A session key, the string stored in a client-side cookie to associate a user with its session
 /// state on the backend.
@@ -17,8 +18,8 @@ use derive_more::{Display, From};
 /// let session_key: Result<SessionKey, _> = key.try_into();
 /// assert!(session_key.is_err());
 /// ```
-#[derive(Debug, PartialEq, Eq)]
-pub struct SessionKey(String);
+#[derive(Debug, Clone)]
+pub struct SessionKey(secrecy::Secret<String>);
 
 impl TryFrom<String> for SessionKey {
     type Error = InvalidSessionKeyError;
@@ -30,14 +31,20 @@ impl TryFrom<String> for SessionKey {
             )
             .into());
         }
-
-        Ok(SessionKey(val))
+        let val_secret = Secret::new(val);
+        Ok(SessionKey(val_secret))
     }
 }
 
-impl AsRef<str> for SessionKey {
-    fn as_ref(&self) -> &str {
+impl AsRef<secrecy::Secret<String>> for SessionKey {
+    fn as_ref(&self) -> &secrecy::Secret<String> {
         &self.0
+    }
+}
+
+impl secrecy::Zeroize for SessionKey {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
     }
 }
 


### PR DESCRIPTION
## PR Type

Feature

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the nightly rustfmt (`cargo +nightly fmt`).

## Overview

It wraps the SessionKey String in a secrecy::Secret which is a breaking change for ppl who have implemented their own storage backend. I, e.g., did that and implemented a backend system for [fred.rs](https://github.com/aembke/fred.rs) because fred has sentinel support. If you guys are interested i can also upstream that.

After that it stores the extracted sessionkey in the Session struct which makes it accessible for users.

Closes #306
Closes #307 It basically finishes that PR. I also pulled their commits and squashed them.

I just need that feature, sooner rather than later, so i thought i implement it rather than poking the ppl involved, on the PR/Issue.

CC @miketwenty1
CC @LukeMathWalker 