### PR TITLE
Add the ability to change the keys

### DIFF
--- a/actix-identity/src/config.rs
+++ b/actix-identity/src/config.rs
@@ -9,6 +9,9 @@ pub(crate) struct Configuration {
     pub(crate) on_logout: LogoutBehaviour,
     pub(crate) login_deadline: Option<Duration>,
     pub(crate) visit_deadline: Option<Duration>,
+    pub(crate) id_key: &'static str,
+    pub(crate) last_visit_unix_timestamp_key: &'static str,
+    pub(crate) login_unix_timestamp_key: &'static str,
 }
 
 impl Default for Configuration {
@@ -17,6 +20,9 @@ impl Default for Configuration {
             on_logout: LogoutBehaviour::PurgeSession,
             login_deadline: None,
             visit_deadline: None,
+            id_key: "actix_identity.user_id",
+            last_visit_unix_timestamp_key: "actix_identity.last_visited_at",
+            login_unix_timestamp_key: "actix_identity.logged_in_at",
         }
     }
 }
@@ -56,6 +62,24 @@ impl IdentityMiddlewareBuilder {
         Self {
             configuration: Configuration::default(),
         }
+    }
+
+    /// Set a custom key to identify the user in the session.
+    pub fn id_key(mut self, key: &'static str) -> Self {
+        self.configuration.id_key = key;
+        self
+    }
+
+    /// Set a custom key to store the last visited unix timestamp.
+    pub fn last_visit_unix_timestamp_key(mut self, key: &'static str) -> Self {
+        self.configuration.last_visit_unix_timestamp_key = key;
+        self
+    }
+
+    /// Set a custom key to store the login unix timestamp.
+    pub fn login_unix_timestamp_key(mut self, key: &'static str) -> Self {
+        self.configuration.login_unix_timestamp_key = key;
+        self
     }
 
     /// Determines how [`Identity::logout`](crate::Identity::logout) affects the current session.

--- a/actix-identity/src/identity.rs
+++ b/actix-identity/src/identity.rs
@@ -158,7 +158,9 @@ impl Identity {
             inner.session.insert(inner.login_unix_timestamp_key, now)?;
         }
         if inner.is_visit_deadline_enabled {
-            inner.session.insert(inner.last_visit_unix_timestamp_key, now)?;
+            inner
+                .session
+                .insert(inner.last_visit_unix_timestamp_key, now)?;
         }
         inner.session.renew();
         Ok(Self(inner))
@@ -229,7 +231,9 @@ impl Identity {
 
     pub(crate) fn set_last_visited_at(&self) -> Result<(), LoginError> {
         let now = OffsetDateTime::now_utc().unix_timestamp();
-        self.0.session.insert(self.0.last_visit_unix_timestamp_key, now)?;
+        self.0
+            .session
+            .insert(self.0.last_visit_unix_timestamp_key, now)?;
         Ok(())
     }
 }

--- a/actix-identity/src/identity.rs
+++ b/actix-identity/src/identity.rs
@@ -82,6 +82,9 @@ pub(crate) struct IdentityInner {
     pub(crate) logout_behaviour: LogoutBehaviour,
     pub(crate) is_login_deadline_enabled: bool,
     pub(crate) is_visit_deadline_enabled: bool,
+    pub(crate) id_key: &'static str,
+    pub(crate) last_visit_unix_timestamp_key: &'static str,
+    pub(crate) login_unix_timestamp_key: &'static str,
 }
 
 impl IdentityInner {
@@ -101,14 +104,10 @@ impl IdentityInner {
     /// Retrieve the user id attached to the current session.
     fn get_identity(&self) -> Result<String, GetIdentityError> {
         self.session
-            .get::<String>(ID_KEY)?
+            .get::<String>(self.id_key)?
             .ok_or_else(|| MissingIdentityError.into())
     }
 }
-
-pub(crate) const ID_KEY: &str = "actix_identity.user_id";
-pub(crate) const LAST_VISIT_UNIX_TIMESTAMP_KEY: &str = "actix_identity.last_visited_at";
-pub(crate) const LOGIN_UNIX_TIMESTAMP_KEY: &str = "actix_identity.logged_in_at";
 
 impl Identity {
     /// Return the user id associated to the current session.
@@ -130,7 +129,7 @@ impl Identity {
     pub fn id(&self) -> Result<String, GetIdentityError> {
         self.0
             .session
-            .get(ID_KEY)?
+            .get(self.0.id_key)?
             .ok_or_else(|| LostIdentityError.into())
     }
 
@@ -153,13 +152,13 @@ impl Identity {
     /// ```
     pub fn login(ext: &Extensions, id: String) -> Result<Self, LoginError> {
         let inner = IdentityInner::extract(ext);
-        inner.session.insert(ID_KEY, id)?;
+        inner.session.insert(inner.id_key, id)?;
         let now = OffsetDateTime::now_utc().unix_timestamp();
         if inner.is_login_deadline_enabled {
-            inner.session.insert(LOGIN_UNIX_TIMESTAMP_KEY, now)?;
+            inner.session.insert(inner.login_unix_timestamp_key, now)?;
         }
         if inner.is_visit_deadline_enabled {
-            inner.session.insert(LAST_VISIT_UNIX_TIMESTAMP_KEY, now)?;
+            inner.session.insert(inner.last_visit_unix_timestamp_key, now)?;
         }
         inner.session.renew();
         Ok(Self(inner))
@@ -191,12 +190,12 @@ impl Identity {
                 self.0.session.purge();
             }
             LogoutBehaviour::DeleteIdentityKeys => {
-                self.0.session.remove(ID_KEY);
+                self.0.session.remove(self.0.id_key);
                 if self.0.is_login_deadline_enabled {
-                    self.0.session.remove(LOGIN_UNIX_TIMESTAMP_KEY);
+                    self.0.session.remove(self.0.login_unix_timestamp_key);
                 }
                 if self.0.is_visit_deadline_enabled {
-                    self.0.session.remove(LAST_VISIT_UNIX_TIMESTAMP_KEY);
+                    self.0.session.remove(self.0.last_visit_unix_timestamp_key);
                 }
             }
         }
@@ -212,7 +211,7 @@ impl Identity {
         Ok(self
             .0
             .session
-            .get(LOGIN_UNIX_TIMESTAMP_KEY)?
+            .get(self.0.login_unix_timestamp_key)?
             .map(OffsetDateTime::from_unix_timestamp)
             .transpose()
             .map_err(SessionExpiryError)?)
@@ -222,7 +221,7 @@ impl Identity {
         Ok(self
             .0
             .session
-            .get(LAST_VISIT_UNIX_TIMESTAMP_KEY)?
+            .get(self.0.last_visit_unix_timestamp_key)?
             .map(OffsetDateTime::from_unix_timestamp)
             .transpose()
             .map_err(SessionExpiryError)?)
@@ -230,7 +229,7 @@ impl Identity {
 
     pub(crate) fn set_last_visited_at(&self) -> Result<(), LoginError> {
         let now = OffsetDateTime::now_utc().unix_timestamp();
-        self.0.session.insert(LAST_VISIT_UNIX_TIMESTAMP_KEY, now)?;
+        self.0.session.insert(self.0.last_visit_unix_timestamp_key, now)?;
         Ok(())
     }
 }

--- a/actix-identity/src/middleware.rs
+++ b/actix-identity/src/middleware.rs
@@ -116,7 +116,7 @@ where
                 is_visit_deadline_enabled: configuration.visit_deadline.is_some(),
                 id_key: configuration.id_key,
                 last_visit_unix_timestamp_key: configuration.last_visit_unix_timestamp_key,
-                login_unix_timestamp_key: configuration.login_unix_timestamp_key
+                login_unix_timestamp_key: configuration.login_unix_timestamp_key,
             };
             req.extensions_mut().insert(identity_inner);
             enforce_policies(&req, &configuration);

--- a/actix-identity/src/middleware.rs
+++ b/actix-identity/src/middleware.rs
@@ -114,6 +114,9 @@ where
                 logout_behaviour: configuration.on_logout.clone(),
                 is_login_deadline_enabled: configuration.login_deadline.is_some(),
                 is_visit_deadline_enabled: configuration.visit_deadline.is_some(),
+                id_key: configuration.id_key,
+                last_visit_unix_timestamp_key: configuration.last_visit_unix_timestamp_key,
+                login_unix_timestamp_key: configuration.login_unix_timestamp_key
             };
             req.extensions_mut().insert(identity_inner);
             enforce_policies(&req, &configuration);


### PR DESCRIPTION
## PR Type

Feature

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the nightly rustfmt (`cargo +nightly fmt`).


## Overview
<!-- Describe the current and new behavior. -->
**Current Behavior**:
The `IdentityMiddleware` uses hardcoded strings as session keys for user identity and timestamps. These keys are:

- "actix_identity.user_id"
- "actix_identity.last_visited_at"
- "actix_identity.logged_in_at"

**New behavior**:
The `IdentityMiddleware` now provides configuration options to allow users to set custom session keys for user identity and timestamps. These keys can be set via the `IdentityMiddlewareBuilder` and are stored in the `Configuration` struct. The default values remain the same as the original hardcoded strings.

<!-- Emphasize any breaking changes. -->
While the default behavior remains the same, users who are extending or interacting directly with the `Configuration` struct or the `IdentityMiddlewareBuilder` might need to adjust their code to accommodate the new fields for custom session keys.