### PR TITLE
fix(cors): The item in "Vary" header should be "Access-Control-Request-Private-Network".

### DIFF
--- a/actix-cors/CHANGES.md
+++ b/actix-cors/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix `add_vary_header` to provide `Access-Control-Request-Private-Network`.
 - Minimum supported Rust version (MSRV) is now 1.68.
 
 ## 0.6.4

--- a/actix-cors/src/inner.rs
+++ b/actix-cors/src/inner.rs
@@ -223,7 +223,7 @@ pub(crate) fn add_vary_header(headers: &mut HeaderMap) {
             val.extend(b", Origin, Access-Control-Request-Method, Access-Control-Request-Headers");
 
             #[cfg(feature = "draft-private-network-access")]
-            val.extend(b", Access-Control-Allow-Private-Network");
+            val.extend(b", Access-Control-Request-Private-Network");
 
             val.try_into().unwrap()
         }
@@ -231,7 +231,7 @@ pub(crate) fn add_vary_header(headers: &mut HeaderMap) {
         #[cfg(feature = "draft-private-network-access")]
         None => HeaderValue::from_static(
             "Origin, Access-Control-Request-Method, Access-Control-Request-Headers, \
-            Access-Control-Allow-Private-Network",
+            Access-Control-Request-Private-Network",
         ),
 
         #[cfg(not(feature = "draft-private-network-access"))]

--- a/actix-cors/tests/tests.rs
+++ b/actix-cors/tests/tests.rs
@@ -272,7 +272,7 @@ async fn test_response() {
     #[cfg(feature = "draft-private-network-access")]
     assert_eq!(
         resp.headers().get(header::VARY).map(HeaderValue::as_bytes),
-        Some(&b"Origin, Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Allow-Private-Network"[..]),
+        Some(&b"Origin, Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Request-Private-Network"[..]),
     );
 
     #[allow(clippy::needless_collect)]
@@ -328,7 +328,7 @@ async fn test_response() {
     #[cfg(feature = "draft-private-network-access")]
     assert_eq!(
         resp.headers().get(header::VARY).map(HeaderValue::as_bytes).unwrap(),
-        b"Accept, Origin, Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Allow-Private-Network",
+        b"Accept, Origin, Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Request-Private-Network",
     );
 
     let cors = Cors::default()
@@ -494,7 +494,7 @@ async fn vary_header_on_all_handled_responses() {
             .expect("response should have Vary header")
             .to_str()
             .unwrap(),
-        "Origin, Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Allow-Private-Network",
+        "Origin, Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Request-Private-Network",
     );
 
     // follow-up regular request
@@ -520,7 +520,7 @@ async fn vary_header_on_all_handled_responses() {
             .expect("response should have Vary header")
             .to_str()
             .unwrap(),
-        "Origin, Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Allow-Private-Network",
+        "Origin, Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Request-Private-Network",
     );
 
     let cors = Cors::default()
@@ -552,7 +552,7 @@ async fn vary_header_on_all_handled_responses() {
             .expect("response should have Vary header")
             .to_str()
             .unwrap(),
-        "Origin, Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Allow-Private-Network",
+        "Origin, Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Request-Private-Network",
     );
 
     // regular request no origin
@@ -575,7 +575,7 @@ async fn vary_header_on_all_handled_responses() {
             .expect("response should have Vary header")
             .to_str()
             .unwrap(),
-        "Origin, Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Allow-Private-Network",
+        "Origin, Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Request-Private-Network",
     );
 }
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] ~Documentation comments have been added / updated.~
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the nightly rustfmt (`cargo +nightly fmt`).


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

The item in `Vary` header should be `Access-Control-Request-Private-Network` rather than `Access-Control-Allow-Private-Network`.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
