### PR TITLE
Add a reference to Apistos to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ These crates are provided by the community.
 | [actix-bincode]            | ![crates.io](https://img.shields.io/crates/v/actix-bincode?label=latest) [![dependency status](https://deps.rs/crate/actix-bincode/latest/status.svg)](https://deps.rs/crate/actix-bincode)                                                              | Bincode payload extractor for Actix Web                                                           |
 | [sentinel-actix]           | ![crates.io](https://img.shields.io/crates/v/sentinel-actix?label=latest) [![dependency status](https://deps.rs/crate/sentinel-actix/latest/status.svg)](https://deps.rs/crate/sentinel-actix)                                                           | General and flexible protection for Actix Web                                                     |
 | [actix-telepathy]          | ![crates.io](https://img.shields.io/crates/v/actix-telepathy?label=latest) [![dependency status](https://deps.rs/crate/actix-telepathy/latest/status.svg)](https://deps.rs/crate/actix-telepathy)                                                        | Build distributed applications with `RemoteActors` and `RemoteMessages`.                          |
+| [apistos]                | ![crates.io](https://img.shields.io/crates/v/apistos?label=latest) [![dependency status](https://deps.rs/crate/apistos/latest/status.svg)](https://deps.rs/crate/apistos)                                                                                    | Automatic OpenAPI v3 documentation for actix-web                                                |
 
 To add a crate to this list, submit a pull request.
 
@@ -82,3 +83,4 @@ To add a crate to this list, submit a pull request.
 [actix-bincode]: https://crates.io/crates/actix-bincode
 [sentinel-actix]: https://crates.io/crates/sentinel-actix
 [actix-telepathy]: https://github.com/wenig/actix-telepathy
+[apistos]: https://github.com/netwo-io/apistos


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type

Other

INSERT_PR_TYPE

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the nightly rustfmt (`cargo +nightly fmt`).

## Overview

This PR only affects the README. I propose adding a reference to a new crate, apistos which generates OpenAPI v3 documentation for actix-web
