### PR TITLE
doc(actix-cors): update MSRV

### DIFF
--- a/actix-cors/README.md
+++ b/actix-cors/README.md
@@ -4,7 +4,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/actix-cors?label=latest)](https://crates.io/crates/actix-cors)
 [![Documentation](https://docs.rs/actix-cors/badge.svg?version=0.7.0)](https://docs.rs/actix-cors/0.7.0)
-![Version](https://img.shields.io/badge/rustc-1.68+-ab6000.svg)
+![Version](https://img.shields.io/badge/rustc-1.75+-ab6000.svg)
 ![MIT or Apache 2.0 licensed](https://img.shields.io/crates/l/actix-cors.svg)
 <br />
 [![Dependency Status](https://deps.rs/crate/actix-cors/0.7.0/status.svg)](https://deps.rs/crate/actix-cors/0.7.0)
@@ -69,4 +69,4 @@ async fn main() -> std::io::Result<()> {
 
 - [API Documentation](https://docs.rs/actix-cors)
 - [Example Project](https://github.com/actix/examples/tree/master/cors)
-- Minimum Supported Rust Version (MSRV): 1.57
+- Minimum Supported Rust Version (MSRV): 1.75


### PR DESCRIPTION
I got the error message:
```
error: package `actix-cors v0.7.0` cannot be built because it requires rustc 1.75 or newer, while the currently active rustc version is 1.74.1
```

actix-cors [uses the workspace's rust-version](https://github.com/actix/actix-extras/blob/master/actix-cors/Cargo.toml#L14), [which is 1.75](https://github.com/actix/actix-extras/blob/master/Cargo.toml#L19) 