### PR TITLE
chore: update futures & futures-core to 0.3.30 across workspace

### DIFF
--- a/actix-identity/Cargo.toml
+++ b/actix-identity/Cargo.toml
@@ -24,7 +24,7 @@ actix-utils = "3"
 actix-web = { version = "4", default-features = false, features = ["cookies", "secure-cookies"] }
 
 derive_more = "0.99.7"
-futures-core = "0.3.7"
+futures-core = "0.3.30"
 serde = { version = "1", features = ["derive"] }
 tracing = { version = "0.1.30", default-features = false, features = ["log"] }
 

--- a/actix-redis/Cargo.toml
+++ b/actix-redis/Cargo.toml
@@ -34,7 +34,7 @@ actix-tls = { version = "3", default-features = false, features = ["connect"] }
 log = "0.4.6"
 backoff = "0.4.0"
 derive_more = "0.99.7"
-futures-core = { version = "0.3.7", default-features = false }
+futures-core = { version = "0.3.30", default-features = false }
 redis-async = "0.16"
 time = "0.3"
 tokio = { version = "1.18.4", features = ["sync"] }

--- a/actix-session/Cargo.toml
+++ b/actix-session/Cargo.toml
@@ -39,7 +39,7 @@ tracing = { version = "0.1.30", default-features = false, features = ["log"] }
 # redis-actor-session
 actix = { version = "0.13", default-features = false, optional = true }
 actix-redis = { version = "0.12", optional = true }
-futures-core = { version = "0.3.7", default-features = false, optional = true }
+futures-core = { version = "0.3.30", default-features = false, optional = true }
 
 # redis-rs-session
 redis = { version = "0.24", default-features = false, features = ["tokio-comp", "connection-manager"], optional = true }

--- a/actix-web-httpauth/Cargo.toml
+++ b/actix-web-httpauth/Cargo.toml
@@ -24,7 +24,7 @@ actix-web = { version = "4.1", default-features = false }
 
 base64 = "0.21"
 futures-core = "0.3.7"
-futures-util = { version = "0.3.17", default-features = false, features = ["std"] }
+futures-util = { version = "0.3.30", default-features = false, features = ["std"] }
 log = "0.4"
 pin-project-lite = "0.2.7"
 

--- a/actix-ws/Cargo.toml
+++ b/actix-ws/Cargo.toml
@@ -18,7 +18,7 @@ actix-codec = "0.5"
 actix-http = { version = "3", default-features = false, features = ["ws"] }
 actix-web = { version = "4", default-features = false }
 bytestring = "1"
-futures-core = "0.3.17"
+futures-core = "0.3.30"
 tokio = { version = "1", features = ["sync"] }
 
 [dev-dependencies]


### PR DESCRIPTION
## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Other

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated. (not applicable)
- [x] Documentation comments have been added / updated. (not applicable)
- [x] A changelog entry has been made for the appropriate packages. (not applicable)
- [x] Format code with the nightly rustfmt (`cargo +nightly fmt`). (not applicable)

## Overview

The ancient `futures` & `futures-core` versions currently pinned are causing obscure issues with e.g. `Identity` (in actix-identity) not being recognized anymore by just adding the `futures` crate (any version) in a project that also depends on actix-identity. Bumping `futures` version in actix-* fixes it.