### PR TITLE
Enable sending Continuations from actix-ws

### DIFF
--- a/actix-ws/CHANGELOG.md
+++ b/actix-ws/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Remove type parameters from `Session::{text, binary}()` methods, replacing with equivalent `impl Trait` parameters.
 - `Session::text()` now receives an `impl Into<ByteString>`, making broadcasting text messages more efficient.
+- Allow sending continuations via `Session::continuation()`
 
 ## 0.2.5
 

--- a/actix-ws/src/fut.rs
+++ b/actix-ws/src/fut.rs
@@ -65,10 +65,13 @@ impl MessageStream {
 
     /// Wait for the next item from the message stream
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # use actix_ws::MessageStream;
+    /// # async fn test(mut stream: MessageStream) {
     /// while let Some(Ok(msg)) = stream.recv().await {
     ///     // handle message
     /// }
+    /// # }
     /// ```
     pub async fn recv(&mut self) -> Option<Result<Message, ProtocolError>> {
         poll_fn(|cx| Pin::new(&mut *self).poll_next(cx)).await

--- a/actix-ws/src/lib.rs
+++ b/actix-ws/src/lib.rs
@@ -8,7 +8,7 @@
 #![doc(html_favicon_url = "https://actix.rs/favicon.ico")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-pub use actix_http::ws::{CloseCode, CloseReason, Message, ProtocolError};
+pub use actix_http::ws::{CloseCode, CloseReason, Item, Message, ProtocolError};
 use actix_http::{
     body::{BodyStream, MessageBody},
     ws::handshake,

--- a/actix-ws/src/session.rs
+++ b/actix-ws/src/session.rs
@@ -45,10 +45,13 @@ impl Session {
 
     /// Send text into the websocket
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # use actix_ws::Session;
+    /// # async fn test(mut session: Session) {
     /// if session.text("Some text").await.is_err() {
     ///     // session closed
     /// }
+    /// # }
     /// ```
     pub async fn text(&mut self, msg: impl Into<ByteString>) -> Result<(), Closed> {
         self.pre_check();
@@ -64,10 +67,13 @@ impl Session {
 
     /// Send raw bytes into the websocket
     ///
-    /// ```rust,ignore
-    /// if session.binary(b"some bytes").await.is_err() {
+    /// ```rust,no_run
+    /// # use actix_ws::Session;
+    /// # async fn test(mut session: Session) {
+    /// if session.binary(&b"some bytes"[..]).await.is_err() {
     ///     // session closed
     /// }
+    /// # }
     /// ```
     pub async fn binary(&mut self, msg: impl Into<Bytes>) -> Result<(), Closed> {
         self.pre_check();
@@ -86,10 +92,13 @@ impl Session {
     /// For many applications, it will be important to send regular pings to keep track of if the
     /// client has disconnected
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # use actix_ws::Session;
+    /// # async fn test(mut session: Session) {
     /// if session.ping(b"").await.is_err() {
     ///     // session is closed
     /// }
+    /// # }
     /// ```
     pub async fn ping(&mut self, msg: &[u8]) -> Result<(), Closed> {
         self.pre_check();
@@ -105,13 +114,16 @@ impl Session {
 
     /// Pong the client
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # use actix_ws::{Message, Session};
+    /// # async fn test(mut session: Session, msg: Message) {
     /// match msg {
     ///     Message::Ping(bytes) => {
     ///         let _ = session.pong(&bytes).await;
     ///     }
     ///     _ => (),
     /// }
+    /// # }
     pub async fn pong(&mut self, msg: &[u8]) -> Result<(), Closed> {
         self.pre_check();
         if let Some(inner) = self.inner.as_mut() {
@@ -135,10 +147,14 @@ impl Session {
     /// Continuations must be initialized with a First variant, and must be terminated by a Last
     /// variant, with only Continue variants sent in between.
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # use actix_ws::{Item, Session};
+    /// # async fn test(mut session: Session) -> Result<(), Box<dyn std::error::Error>> {
     /// session.continuation(Item::FirstText("Hello".into())).await?;
-    /// session.continuation(Item::Continue(b", World".into())).await?;
-    /// session.continuation(Item::Last(b"!".into())).await?;
+    /// session.continuation(Item::Continue(b", World"[..].into())).await?;
+    /// session.continuation(Item::Last(b"!"[..].into())).await?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn continuation(&mut self, msg: Item) -> Result<(), Closed> {
         self.pre_check();
@@ -156,8 +172,11 @@ impl Session {
     ///
     /// All clones will return `Err(Closed)` if used after this call
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # use actix_ws::{Closed, Session};
+    /// # async fn test(mut session: Session) -> Result<(), Closed> {
     /// session.close(None).await
+    /// # }
     /// ```
     pub async fn close(mut self, reason: Option<CloseReason>) -> Result<(), Closed> {
         self.pre_check();


### PR DESCRIPTION
## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Feature

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the nightly rustfmt (`cargo +nightly fmt`).

## Overview
- Enable manually sending Continuations from actix-ws. Add a scary warning to the documentation for this method.
- Convert `ignore` doctests to `no_run` doctests

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
