### PR TITLE
actix-ws: take the encoded buffer when yielding rather than split it

### DIFF
--- a/actix-ws/CHANGELOG.md
+++ b/actix-ws/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Take the encoded buffer when yielding bytes in the response stream rather than splitting the buffer, reducing memory use
 - Remove type parameters from `Session::{text, binary}()` methods, replacing with equivalent `impl Trait` parameters.
 - `Session::text()` now receives an `impl Into<ByteString>`, making broadcasting text messages more efficient.
 - Allow sending continuations via `Session::continuation()`

--- a/actix-ws/src/fut.rs
+++ b/actix-ws/src/fut.rs
@@ -108,7 +108,7 @@ impl Stream for StreamingBody {
         }
 
         if !this.buf.is_empty() {
-            return Poll::Ready(Some(Ok(this.buf.split().freeze())));
+            return Poll::Ready(Some(Ok(std::mem::take(&mut this.buf).freeze())));
         }
 
         Poll::Pending


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Bug fix

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the nightly rustfmt (`cargo +nightly fmt`).

## Overview
Prevent the actix-ws internal buffer from growing continuously by taking it rather than splitting it

same as in https://github.com/actix/actix-web/pull/3369

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
