### PR TITLE
feat(ws): allow setting max frame size.

### DIFF
--- a/actix-ws/CHANGELOG.md
+++ b/actix-ws/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Allow changing the max frame size, using the newly-added `MessageStream::max_size` method.
 - Remove type parameters from `Session::{text, binary}()` methods, replacing with equivalent `impl Trait` parameters.
 - `Session::text()` now receives an `impl Into<ByteString>`, making broadcasting text messages more efficient.
 - Allow sending continuations via `Session::continuation()`

--- a/actix-ws/src/fut.rs
+++ b/actix-ws/src/fut.rs
@@ -76,6 +76,12 @@ impl MessageStream {
     pub async fn recv(&mut self) -> Option<Result<Message, ProtocolError>> {
         poll_fn(|cx| Pin::new(&mut *self).poll_next(cx)).await
     }
+
+    /// Set max frame size. See `actix-http::ws::Codec::max_size`.
+    pub fn max_size(mut self, size: usize) -> Self {
+        self.codec = self.codec.max_size(size);
+        self
+    }
 }
 
 impl Stream for StreamingBody {


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Feature

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
   *I don't see any tests for the module in question, so this was skipped.*
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the nightly rustfmt (`cargo +nightly fmt`).

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

This PR allows changing the maximum frame size when receiving websocket data. Without this, there's no way to change the default size (64 KB).

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
