### PR TITLE
Update websocket example to use futures_util::StreamExt

### DIFF
--- a/actix-ws/README.md
+++ b/actix-ws/README.md
@@ -20,6 +20,7 @@
 ```rust
 use actix_web::{middleware::Logger, web, App, HttpRequest, HttpServer, Responder};
 use actix_ws::Message;
+use futures_util::StreamExt;
 
 async fn ws(req: HttpRequest, body: web::Payload) -> actix_web::Result<impl Responder> {
     let (response, mut session, mut msg_stream) = actix_ws::handle(&req, body)?;


### PR DESCRIPTION
The only way I was able to get this example code to run was by installing futures_util and importing futures_util::StreamExt. It feels like there isn't supposed to be an additional dependency here (I am relatively new to Rust let alone package management like this), but the example by itself throws an error without doing this.

<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Other

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the nightly rustfmt (`cargo +nightly fmt`).

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

It's just an update to the example code

<!-- If this PR fixes or closes an issue, reference it here. -->

N/A to my knowledge
