### PR TITLE
fix: ensure TCP connection is properly shut down when Session is dropped

### DIFF
--- a/actix-ws/CHANGELOG.md
+++ b/actix-ws/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Ensure TCP connection is properly shut down when session is dropped
 
 ## 0.3.0
 

--- a/actix-ws/CHANGELOG.md
+++ b/actix-ws/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Unreleased
-- Ensure TCP connection is properly shut down when session is dropped
+
+- Ensure TCP connection is properly shut down when session is dropped.
 
 ## 0.3.0
 

--- a/actix-ws/src/stream.rs
+++ b/actix-ws/src/stream.rs
@@ -145,6 +145,10 @@ impl Stream for StreamingBody {
             return Poll::Ready(Some(Ok(mem::take(&mut this.buf).freeze())));
         }
 
+        if this.closing {
+            return Poll::Ready(None);
+        }
+
         Poll::Pending
     }
 }


### PR DESCRIPTION
## PR Type

Bug fix

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the nightly rustfmt (`cargo +nightly fmt`).

## Overview

When a `Session` falls out of scope, `StreamingBody`'s `poll_next` ought to return `Poll::Ready(None)`, not `Poll::Pending`.

Relates to: https://github.com/actix/actix-web/pull/3093