### PR TITLE
actix-session: make Session implementation of FromRequest infallible

### DIFF
--- a/actix-session/CHANGES.md
+++ b/actix-session/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `Session` implementation of `FromRequest` now errors with `Infallible` rather than `actix_web::error::Error`.
+
 ## 0.11.0
 
 - Add `Session::contains_key` method.

--- a/actix-session/src/session.rs
+++ b/actix-session/src/session.rs
@@ -1,6 +1,7 @@
 use std::{
     cell::{Ref, RefCell},
     collections::HashMap,
+    convert::Infallible,
     error::Error as StdError,
     mem,
     rc::Rc,
@@ -10,7 +11,6 @@ use actix_utils::future::{ready, Ready};
 use actix_web::{
     body::BoxBody,
     dev::{Extensions, Payload, ServiceRequest, ServiceResponse},
-    error::Error,
     FromRequest, HttpMessage, HttpRequest, HttpResponse, ResponseError,
 };
 use anyhow::Context;
@@ -363,8 +363,8 @@ impl Session {
 /// }
 /// ```
 impl FromRequest for Session {
-    type Error = Error;
-    type Future = Ready<Result<Session, Error>>;
+    type Error = Infallible;
+    type Future = Ready<Result<Session, Self::Error>>;
 
     #[inline]
     fn from_request(req: &HttpRequest, _: &mut Payload) -> Self::Future {


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Minor refactor of error type.

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the nightly rustfmt (`cargo +nightly fmt`).

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->

I have switched the error type of `FromRequest` for `Session` from `actix_web::error::Error` to `Infallible`.

The current implementation of `FromRequest` for `Session` is as follows:

```RS
impl FromRequest for Session {
    type Error = Error;
    type Future = Ready<Result<Session, Error>>;

    #[inline]
    fn from_request(req: &HttpRequest, _: &mut Payload) -> Self::Future {
        ready(Ok(Session::get_session(&mut req.extensions_mut())))
    }
}
```

The error type is `actix_web::error::Error` even though there is no error case. While users don't usually call `from_request` manually, in the case that they do, it's not immediately apparent that the result here can be safely unwrapped, so `Infallible` is more appropriate. I noticed this while I was trying to access `Session` in the `FromRequest` implementation for one of my project's own types.

Hopefully I didn't miss some reason this is a bad idea, thanks!