### PR TITLE
feat(tracing-actix-web): add opentelemetry 0.32 support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,8 +66,16 @@ jobs:
           reporter: github-pr-check
           github_token: ${{ secrets.GITHUB_TOKEN }}
           clippy_flags: >-
-            --workspace --all-features --exclude actix-settings --tests --examples --bins --
+            --workspace --all-features --exclude actix-settings --exclude tracing-actix-web
+            --tests --examples --bins --
             -A unknown_lints -D clippy::todo -D clippy::dbg_macro
+
+      - name: Check tracing-actix-web with Clippy
+        run: |
+          cargo clippy -p tracing-actix-web --lib --tests --examples --bins -- -A unknown_lints -D clippy::todo -D clippy::dbg_macro
+          cargo clippy -p tracing-actix-web --lib --tests --examples --bins --features uuid_v7 -- -A unknown_lints -D clippy::todo -D clippy::dbg_macro
+          cargo clippy -p tracing-actix-web --lib --tests --examples --bins --features opentelemetry_0_13 -- -A unknown_lints -D clippy::todo -D clippy::dbg_macro
+          cargo clippy -p tracing-actix-web --lib --tests --examples --bins --features opentelemetry_0_32 -- -A unknown_lints -D clippy::todo -D clippy::dbg_macro
 
       - name: Check actix-settings with Clippy
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
  "derive_more",
  "env_logger",
  "futures-core",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "tracing",
  "uuid",
@@ -969,14 +969,14 @@ name = "custom-root-span"
 version = "0.1.0"
 dependencies = [
  "actix-web",
- "opentelemetry 0.31.0",
+ "opentelemetry 0.32.0",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry_sdk 0.32.0",
  "tracing",
  "tracing-actix-web",
  "tracing-bunyan-formatter",
- "tracing-opentelemetry 0.32.1",
+ "tracing-opentelemetry 0.33.0",
  "tracing-subscriber 0.3.23",
 ]
 
@@ -2382,45 +2382,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-http"
-version = "0.31.0"
+name = "opentelemetry"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
- "async-trait",
- "bytes",
- "http 1.4.0",
- "opentelemetry 0.31.0",
- "reqwest 0.12.28",
-]
-
-[[package]]
-name = "opentelemetry-otlp"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
-dependencies = [
- "http 1.4.0",
- "opentelemetry 0.31.0",
- "opentelemetry-http",
- "opentelemetry-proto",
- "opentelemetry_sdk 0.31.0",
- "prost",
- "reqwest 0.12.28",
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
  "thiserror 2.0.18",
- "tokio",
- "tonic",
  "tracing",
 ]
 
 [[package]]
-name = "opentelemetry-proto"
-version = "0.31.0"
+name = "opentelemetry-http"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
- "opentelemetry 0.31.0",
- "opentelemetry_sdk 0.31.0",
+ "async-trait",
+ "bytes",
+ "http 1.4.0",
+ "opentelemetry 0.32.0",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http 1.4.0",
+ "opentelemetry 0.32.0",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk 0.32.0",
+ "prost",
+ "reqwest",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tonic-types",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry 0.32.0",
+ "opentelemetry_sdk 0.32.0",
  "prost",
  "tonic",
  "tonic-prost",
@@ -2428,9 +2442,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
+checksum = "6ca2f98a0437b427b4b08f19f1caa3c44db885a202bc12cfea13d6c702243d68"
 
 [[package]]
 name = "opentelemetry_api"
@@ -2721,15 +2735,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "368afaed344110f40b179bb8fbe54bc52d98f9bd2b281799ef32487c2650c956"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.31.0",
+ "opentelemetry 0.32.0",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
@@ -2759,14 +2774,14 @@ name = "otel"
 version = "0.1.0"
 dependencies = [
  "actix-web",
- "opentelemetry 0.31.0",
+ "opentelemetry 0.32.0",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry_sdk 0.32.0",
  "tracing",
  "tracing-actix-web",
  "tracing-bunyan-formatter",
- "tracing-opentelemetry 0.32.1",
+ "tracing-opentelemetry 0.33.0",
  "tracing-subscriber 0.3.23",
 ]
 
@@ -2928,6 +2943,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -3128,40 +3152,6 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 1.4.0",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
@@ -3170,7 +3160,9 @@ dependencies = [
  "bytes",
  "cookie 0.18.1",
  "cookie_store",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http 1.4.0",
  "http-body",
  "http-body-util",
@@ -3795,6 +3787,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a875a902255423d34c1f20838ab374126db8eb41625b7947a1d54113b0b7399"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3880,6 +3883,7 @@ dependencies = [
  "opentelemetry 0.29.1",
  "opentelemetry 0.30.0",
  "opentelemetry 0.31.0",
+ "opentelemetry 0.32.0",
  "pin-project",
  "tracing",
  "tracing-bunyan-formatter",
@@ -3903,6 +3907,7 @@ dependencies = [
  "tracing-opentelemetry 0.30.0",
  "tracing-opentelemetry 0.31.0",
  "tracing-opentelemetry 0.32.1",
+ "tracing-opentelemetry 0.33.0",
  "tracing-subscriber 0.3.23",
  "uuid",
 ]
@@ -4266,6 +4271,22 @@ checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
  "opentelemetry 0.31.0",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log 0.2.0",
+ "tracing-subscriber 0.3.23",
+ "web-time 1.1.0",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry 0.32.0",
  "smallvec",
  "tracing",
  "tracing-core",

--- a/actix-ws/src/lib.rs
+++ b/actix-ws/src/lib.rs
@@ -130,10 +130,7 @@ fn select_protocol<'a>(req: &'a HttpRequest, protocols: &[&str]) -> Option<&'a s
                 continue;
             }
 
-            if protocols
-                .iter()
-                .any(|supported_protocol| *supported_protocol == requested_protocol)
-            {
+            if protocols.contains(&requested_protocol) {
                 return Some(requested_protocol);
             }
         }

--- a/justfile
+++ b/justfile
@@ -17,7 +17,16 @@ msrv_rustup := "+" + msrv
 # Run Clippy over workspace.
 [group("lint")]
 clippy:
-    cargo {{ toolchain }} clippy --workspace --all-targets --all-features
+    # `tracing-actix-web` and `actix-settings` have mutually exclusive feature sets, therefore
+    # `--all-features` cannot be used for the entire workspace.
+    cargo {{ toolchain }} clippy --workspace --all-targets --all-features --exclude tracing-actix-web --exclude actix-settings
+    cargo {{ toolchain }} clippy -p tracing-actix-web --lib --tests --examples --bins
+    cargo {{ toolchain }} clippy -p tracing-actix-web --lib --tests --examples --bins --features uuid_v7
+    cargo {{ toolchain }} clippy -p tracing-actix-web --lib --tests --examples --bins --features opentelemetry_0_13
+    cargo {{ toolchain }} clippy -p tracing-actix-web --lib --tests --examples --bins --features opentelemetry_0_32
+    cargo {{ toolchain }} clippy -p actix-settings --tests --examples --bins
+    cargo {{ toolchain }} clippy -p actix-settings --all-targets --features openssl
+    cargo {{ toolchain }} clippy -p actix-settings --all-targets --features rustls-0_23
 
 # Format project.
 [group("lint")]

--- a/justfile
+++ b/justfile
@@ -109,6 +109,7 @@ test-docs:
     cargo {{ toolchain }} check -p tracing-actix-web --all-targets --features opentelemetry_0_29
     cargo {{ toolchain }} check -p tracing-actix-web --all-targets --features opentelemetry_0_30
     cargo {{ toolchain }} check -p tracing-actix-web --all-targets --features opentelemetry_0_31
+    cargo {{ toolchain }} check -p tracing-actix-web --all-targets --features opentelemetry_0_32
 
 # Test `actix-settings` with feature sets that cannot be covered by `--all-features`.
 [group("test")]
@@ -131,7 +132,7 @@ ci-test-tracing-actix-web:
     cargo {{ toolchain }} test -p tracing-actix-web --lib --tests --examples --bins --no-fail-fast
     cargo {{ toolchain }} test -p tracing-actix-web --lib --tests --examples --bins --no-fail-fast --features uuid_v7
     cargo {{ toolchain }} test -p tracing-actix-web --lib --tests --examples --bins --no-fail-fast --features opentelemetry_0_13
-    cargo {{ toolchain }} test -p tracing-actix-web --lib --tests --examples --bins --no-fail-fast --features opentelemetry_0_31
+    cargo {{ toolchain }} test -p tracing-actix-web --lib --tests --examples --bins --no-fail-fast --features opentelemetry_0_32
 
 # Document crates in workspace.
 [group("docs")]
@@ -141,7 +142,7 @@ doc *args: && doc-set-workspace-crates
     # `--all-features` cannot be used for the entire workspace.
     RUSTDOCFLAGS="--cfg=docsrs -D warnings" cargo +nightly doc --workspace --no-deps --all-features --exclude tracing-actix-web --exclude actix-settings {{ args }}
     RUSTDOCFLAGS="--cfg=docsrs -D warnings" cargo +nightly doc -p actix-settings --no-deps --all-features {{ args }}
-    RUSTDOCFLAGS="--cfg=docsrs -D warnings" cargo +nightly doc -p tracing-actix-web --no-deps --features "uuid_v7 opentelemetry_0_31" {{ args }}
+    RUSTDOCFLAGS="--cfg=docsrs -D warnings" cargo +nightly doc -p tracing-actix-web --no-deps --features "uuid_v7 opentelemetry_0_32" {{ args }}
 
 [group("docs")]
 [private]

--- a/tracing-actix-web/CHANGELOG.md
+++ b/tracing-actix-web/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Minimum supported Rust version (MSRV) is now 1.88.
 - Ensure the OpenTelemetry `trace_id` is populated when request spans are created. [#724]
+- Support OpenTelemetry 0.32.
 
 [#724]: https://github.com/actix/actix-extras/pull/724
 

--- a/tracing-actix-web/Cargo.toml
+++ b/tracing-actix-web/Cargo.toml
@@ -91,6 +91,10 @@ opentelemetry_0_31 = [
     "opentelemetry_0_31_pkg",
     "tracing-opentelemetry_0_32_pkg",
 ]
+opentelemetry_0_32 = [
+    "opentelemetry_0_32_pkg",
+    "tracing-opentelemetry_0_33_pkg",
+]
 emit_event_on_error = []
 uuid_v7 = ["uuid/v7"]
 
@@ -119,6 +123,7 @@ opentelemetry_0_28_pkg = { package = "opentelemetry", version = "0.28", optional
 opentelemetry_0_29_pkg = { package = "opentelemetry", version = "0.29", optional = true }
 opentelemetry_0_30_pkg = { package = "opentelemetry", version = "0.30", optional = true }
 opentelemetry_0_31_pkg = { package = "opentelemetry", version = "0.31", optional = true }
+opentelemetry_0_32_pkg = { package = "opentelemetry", version = "0.32", optional = true }
 tracing-opentelemetry_0_12_pkg = { package = "tracing-opentelemetry", version = "0.12", optional = true }
 tracing-opentelemetry_0_13_pkg = { package = "tracing-opentelemetry", version = "0.13", optional = true }
 tracing-opentelemetry_0_14_pkg = { package = "tracing-opentelemetry", version = "0.14", optional = true }
@@ -138,6 +143,7 @@ tracing-opentelemetry_0_29_pkg = { package = "tracing-opentelemetry", version = 
 tracing-opentelemetry_0_30_pkg = { package = "tracing-opentelemetry", version = "0.30", optional = true }
 tracing-opentelemetry_0_31_pkg = { package = "tracing-opentelemetry", version = "0.31", optional = true }
 tracing-opentelemetry_0_32_pkg = { package = "tracing-opentelemetry", version = "0.32", optional = true }
+tracing-opentelemetry_0_33_pkg = { package = "tracing-opentelemetry", version = "0.33", optional = true }
 
 [dev-dependencies]
 actix-web = { version = "4", default-features = false, features = ["macros"] }

--- a/tracing-actix-web/README.md
+++ b/tracing-actix-web/README.md
@@ -65,6 +65,7 @@ actix-web = "4"
 - `opentelemetry_0_29`: same as above but using `opentelemetry` 0.29;
 - `opentelemetry_0_30`: same as above but using `opentelemetry` 0.30;
 - `opentelemetry_0_31`: same as above but using `opentelemetry` 0.31;
+- `opentelemetry_0_32`: same as above but using `opentelemetry` 0.32;
 - `emit_event_on_error`: emit a [`tracing`] event when request processing fails with an error (enabled by default).
 - `uuid_v7`: use the UUID v7 implementation inside [`RequestId`] instead of UUID v4 (disabled by default).
 ## Quickstart

--- a/tracing-actix-web/examples/custom-root-span/Cargo.toml
+++ b/tracing-actix-web/examples/custom-root-span/Cargo.toml
@@ -7,12 +7,12 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 actix-web = "4"
-opentelemetry = "0.31"
-opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic"] }
-opentelemetry_sdk = { version = "0.31", features = ["rt-tokio-current-thread"] }
-opentelemetry-semantic-conventions = "0.31"
-tracing-opentelemetry = "0.32"
+opentelemetry = "0.32"
+opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic"] }
+opentelemetry_sdk = { version = "0.32", features = ["rt-tokio-current-thread"] }
+opentelemetry-semantic-conventions = "0.32"
+tracing-opentelemetry = "0.33"
 tracing = "0.1"
-tracing-actix-web = { path = "../..", features = ["opentelemetry_0_31"] }
+tracing-actix-web = { path = "../..", features = ["opentelemetry_0_32"] }
 tracing-bunyan-formatter = "0.3"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }

--- a/tracing-actix-web/examples/opentelemetry/Cargo.toml
+++ b/tracing-actix-web/examples/opentelemetry/Cargo.toml
@@ -7,12 +7,12 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 actix-web = "4"
-opentelemetry = "0.31"
-opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic"] }
-opentelemetry_sdk = { version = "0.31", features = ["rt-tokio-current-thread"] }
-opentelemetry-semantic-conventions = "0.31"
+opentelemetry = "0.32"
+opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic"] }
+opentelemetry_sdk = { version = "0.32", features = ["rt-tokio-current-thread"] }
+opentelemetry-semantic-conventions = "0.32"
 tracing = "0.1"
-tracing-actix-web = { path = "../..", features = ["opentelemetry_0_31"] }
+tracing-actix-web = { path = "../..", features = ["opentelemetry_0_32"] }
 tracing-bunyan-formatter = "0.3"
-tracing-opentelemetry = "0.32"
+tracing-opentelemetry = "0.33"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }

--- a/tracing-actix-web/src/lib.rs
+++ b/tracing-actix-web/src/lib.rs
@@ -38,6 +38,7 @@
 //! - `opentelemetry_0_29`: same as above but using `opentelemetry` 0.29;
 //! - `opentelemetry_0_30`: same as above but using `opentelemetry` 0.30;
 //! - `opentelemetry_0_31`: same as above but using `opentelemetry` 0.31;
+//! - `opentelemetry_0_32`: same as above but using `opentelemetry` 0.32;
 //! - `emit_event_on_error`: emit a [`tracing`] event when request processing fails with an error (enabled by default).
 //! - `uuid_v7`: use the UUID v7 implementation inside [`RequestId`] instead of UUID v4 (disabled by default).
 //!
@@ -321,6 +322,7 @@ mutually_exclusive_features::none_or_one_of!(
     "opentelemetry_0_29",
     "opentelemetry_0_30",
     "opentelemetry_0_31",
+    "opentelemetry_0_32",
 );
 
 #[cfg(any(
@@ -343,5 +345,6 @@ mutually_exclusive_features::none_or_one_of!(
     feature = "opentelemetry_0_29",
     feature = "opentelemetry_0_30",
     feature = "opentelemetry_0_31",
+    feature = "opentelemetry_0_32",
 ))]
 mod otel;

--- a/tracing-actix-web/src/otel.rs
+++ b/tracing-actix-web/src/otel.rs
@@ -38,6 +38,8 @@ use opentelemetry_0_29_pkg as opentelemetry;
 use opentelemetry_0_30_pkg as opentelemetry;
 #[cfg(feature = "opentelemetry_0_31")]
 use opentelemetry_0_31_pkg as opentelemetry;
+#[cfg(feature = "opentelemetry_0_32")]
+use opentelemetry_0_32_pkg as opentelemetry;
 #[cfg(feature = "opentelemetry_0_13")]
 use tracing_opentelemetry_0_12_pkg as tracing_opentelemetry;
 #[cfg(feature = "opentelemetry_0_14")]
@@ -76,6 +78,8 @@ use tracing_opentelemetry_0_30_pkg as tracing_opentelemetry;
 use tracing_opentelemetry_0_31_pkg as tracing_opentelemetry;
 #[cfg(feature = "opentelemetry_0_31")]
 use tracing_opentelemetry_0_32_pkg as tracing_opentelemetry;
+#[cfg(feature = "opentelemetry_0_32")]
+use tracing_opentelemetry_0_33_pkg as tracing_opentelemetry;
 
 pub(crate) struct RequestHeaderCarrier<'a> {
     headers: &'a actix_web::http::header::HeaderMap,
@@ -129,6 +133,7 @@ pub(crate) fn extract_trace_id(req: &ServiceRequest) -> Option<String> {
         feature = "opentelemetry_0_29",
         feature = "opentelemetry_0_30",
         feature = "opentelemetry_0_31",
+        feature = "opentelemetry_0_32",
     )))]
     let trace_id = span_context.trace_id().to_hex();
 
@@ -148,6 +153,7 @@ pub(crate) fn extract_trace_id(req: &ServiceRequest) -> Option<String> {
         feature = "opentelemetry_0_29",
         feature = "opentelemetry_0_30",
         feature = "opentelemetry_0_31",
+        feature = "opentelemetry_0_32",
     ))]
     let trace_id = format!("{:032x}", span_context.trace_id());
 
@@ -180,6 +186,7 @@ pub(crate) fn set_otel_parent(req: &ServiceRequest, span: &tracing::Span) {
         feature = "opentelemetry_0_29",
         feature = "opentelemetry_0_30",
         feature = "opentelemetry_0_31",
+        feature = "opentelemetry_0_32",
     )))]
     let trace_id = span.context().span().span_context().trace_id().to_hex();
 
@@ -199,6 +206,7 @@ pub(crate) fn set_otel_parent(req: &ServiceRequest, span: &tracing::Span) {
         feature = "opentelemetry_0_29",
         feature = "opentelemetry_0_30",
         feature = "opentelemetry_0_31",
+        feature = "opentelemetry_0_32",
     ))]
     let trace_id = {
         let id = span.context().span().span_context().trace_id();

--- a/tracing-actix-web/src/otel.rs
+++ b/tracing-actix-web/src/otel.rs
@@ -167,6 +167,9 @@ pub(crate) fn set_otel_parent(req: &ServiceRequest, span: &tracing::Span) {
     let parent_context = opentelemetry::global::get_text_map_propagator(|propagator| {
         propagator.extract(&RequestHeaderCarrier::new(req.headers()))
     });
+    #[cfg(not(any(feature = "opentelemetry_0_31", feature = "opentelemetry_0_32")))]
+    span.set_parent(parent_context);
+    #[cfg(any(feature = "opentelemetry_0_31", feature = "opentelemetry_0_32"))]
     let _ = span.set_parent(parent_context);
     // If we have a remote parent span, this will be the parent's trace identifier.
     // If not, it will be the newly generated trace identifier with this request as root span.

--- a/tracing-actix-web/src/root_span_macro.rs
+++ b/tracing-actix-web/src/root_span_macro.rs
@@ -222,6 +222,7 @@ pub mod private {
             feature = "opentelemetry_0_29",
             feature = "opentelemetry_0_30",
             feature = "opentelemetry_0_31",
+            feature = "opentelemetry_0_32",
         ))]
         {
             crate::otel::extract_trace_id(req)
@@ -246,6 +247,7 @@ pub mod private {
             feature = "opentelemetry_0_29",
             feature = "opentelemetry_0_30",
             feature = "opentelemetry_0_31",
+            feature = "opentelemetry_0_32",
         )))]
         {
             None
@@ -278,6 +280,7 @@ pub mod private {
             feature = "opentelemetry_0_29",
             feature = "opentelemetry_0_30",
             feature = "opentelemetry_0_31",
+            feature = "opentelemetry_0_32",
         ))]
         crate::otel::set_otel_parent(req, span);
     }


### PR DESCRIPTION
Adds the `opentelemetry_0_32` feature backed by `opentelemetry` 0.32 and `tracing-opentelemetry` 0.33, following the same pattern as all previous version bumps. Updates both examples and the justfile CI targets to track the latest version.

<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Feature

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the nightly rustfmt (`cargo +nightly fmt`).

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

Add support for opentelemetry 0.32. I have simply added the feature and updated the packages, I have tested it on some of our packages and found no issues.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->


