### PR TITLE
Be more precse about Cors::permissive() about HTTP methods

### DIFF
--- a/actix-cors/src/builder.rs
+++ b/actix-cors/src/builder.rs
@@ -92,7 +92,7 @@ impl Cors {
     /// Constructs a very permissive set of defaults for quick development. (Not recommended for
     /// production use.)
     ///
-    /// *All* origins, methods, request headers and exposed headers allowed. Credentials supported.
+    /// *All* origins, request headers, exposed headers and methods recognized by [`actix_web::http::Method`] allowed. Credentials supported.
     /// Max age 1 hour. Does not send wildcard.
     pub fn permissive() -> Self {
         let inner = Inner {


### PR DESCRIPTION
## PR Type

Other 

## PR Checklist
- [✓] Documentation comments have been added / updated.

## Overview

Be more precse about Cors::permissive() about HTTP methods. The old documentation suggest it accepts all HTTP methods (as in: any string). But it doesn't accept the new QUERY HTTP method. The new method isn't accepted as upstream hasn't added it yet. 