### PR TITLE
fix(cors): add CORS headers to error responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.14.1"
+version = "4.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58356675d8c86d2e720480645a0316808471a62d0073f6a3b98810a5e0ca0e73"
+checksum = "bbacab3593b6b4f7be815076fc52d60a83c873426824675417e2abdd229e2e36"
 dependencies = [
  "actix-codec",
  "actix-http",

--- a/actix-cors/CHANGES.md
+++ b/actix-cors/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add configured CORS response headers to error responses.
 - Minimum supported Rust version (MSRV) is now 1.88.
 
 ## 0.7.1

--- a/actix-cors/Cargo.toml
+++ b/actix-cors/Cargo.toml
@@ -21,7 +21,7 @@ draft-private-network-access = []
 
 [dependencies]
 actix-utils = "3"
-actix-web = { version = "4", default-features = false }
+actix-web = { version = "4.15", default-features = false }
 
 derive_more = { version = "2", features = ["display", "error"] }
 futures-util = { version = "0.3.17", default-features = false, features = ["std"] }
@@ -30,7 +30,7 @@ once_cell = "1"
 smallvec = "1"
 
 [dev-dependencies]
-actix-web = { version = "4", default-features = false, features = ["macros"] }
+actix-web = { version = "4.15", default-features = false, features = ["macros"] }
 env_logger = "0.11"
 regex = "1.12"
 

--- a/actix-cors/src/middleware.rs
+++ b/actix-cors/src/middleware.rs
@@ -5,7 +5,7 @@ use actix_web::{
     body::{EitherBody, MessageBody},
     dev::{forward_ready, Service, ServiceRequest, ServiceResponse},
     http::{
-        header::{self, HeaderValue},
+        header::{self, HeaderMap, HeaderValue},
         Method,
     },
     Error, HttpResponse, Result,
@@ -125,72 +125,60 @@ impl<S> CorsMiddleware<S> {
         req.into_response(res)
     }
 
-    fn augment_response<B>(
+    fn augment_response_headers(
         inner: &Inner,
-        origin_allowed: bool,
-        mut res: ServiceResponse<B>,
-    ) -> ServiceResponse<B> {
-        if origin_allowed {
-            if let Some(origin) = inner.access_control_allow_origin(res.request().head()) {
-                res.headers_mut()
-                    .insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, origin);
-            };
+        allow_origin: Option<HeaderValue>,
+        _private_network_access_requested: bool,
+        headers: &mut HeaderMap,
+    ) {
+        if let Some(origin) = allow_origin {
+            headers.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, origin);
         }
 
         if let Some(ref expose) = inner.expose_headers_baked {
             log::trace!("exposing selected headers: {:?}", expose);
 
-            res.headers_mut()
-                .insert(header::ACCESS_CONTROL_EXPOSE_HEADERS, expose.clone());
+            headers.insert(header::ACCESS_CONTROL_EXPOSE_HEADERS, expose.clone());
         } else if matches!(inner.expose_headers, AllOrSome::All) {
             // intersperse_header_values requires that argument is non-empty
-            if !res.headers().is_empty() {
-                // extract header names from request
-                let expose_all_request_headers = res
-                    .headers()
+            if !headers.is_empty() {
+                // extract header names from response
+                let expose_all_response_headers = headers
                     .keys()
                     .map(|name| name.as_str())
                     .collect::<HashSet<_>>();
 
                 // create comma separated string of header names
-                let expose_headers_value = intersperse_header_values(&expose_all_request_headers);
+                let expose_headers_value = intersperse_header_values(&expose_all_response_headers);
 
                 log::trace!(
-                    "exposing all headers from request: {:?}",
+                    "exposing all headers from response: {:?}",
                     expose_headers_value
                 );
 
                 // add header names to expose response header
-                res.headers_mut()
-                    .insert(header::ACCESS_CONTROL_EXPOSE_HEADERS, expose_headers_value);
+                headers.insert(header::ACCESS_CONTROL_EXPOSE_HEADERS, expose_headers_value);
             }
         }
 
         if inner.supports_credentials {
-            res.headers_mut().insert(
+            headers.insert(
                 header::ACCESS_CONTROL_ALLOW_CREDENTIALS,
                 HeaderValue::from_static("true"),
             );
         }
 
         #[cfg(feature = "draft-private-network-access")]
-        if inner.allow_private_network_access
-            && res
-                .request()
-                .headers()
-                .contains_key("access-control-request-private-network")
-        {
-            res.headers_mut().insert(
+        if inner.allow_private_network_access && _private_network_access_requested {
+            headers.insert(
                 header::HeaderName::from_static("access-control-allow-private-network"),
                 HeaderValue::from_static("true"),
             );
         }
 
         if inner.vary_header {
-            add_vary_header(res.headers_mut());
+            add_vary_header(headers);
         }
-
-        res
     }
 }
 
@@ -208,23 +196,25 @@ where
     forward_ready!(service);
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
+        let inner = Rc::clone(&self.inner);
+
         let origin = req.headers().get(header::ORIGIN);
 
         // handle preflight requests
-        if self.inner.preflight && Self::is_request_preflight(&req) {
+        if inner.preflight && Self::is_request_preflight(&req) {
             let res = self.handle_preflight(req);
             return ok(res.map_into_right_body()).boxed_local();
         }
 
         // only check actual requests with a origin header
-        let origin_allowed = match (origin, self.inner.validate_origin(req.head())) {
-            (None, _) => false,
-            (_, Ok(origin_allowed)) => origin_allowed,
+        let allow_origin = match (origin, inner.validate_origin(req.head())) {
+            (None, _) | (_, Ok(false)) => None,
+            (_, Ok(true)) => inner.access_control_allow_origin(req.head()),
             (_, Err(err)) => {
                 debug!("origin validation failed; inner service is not called");
                 let mut res = req.error_response(err);
 
-                if self.inner.vary_header {
+                if inner.vary_header {
                     add_vary_header(res.headers_mut());
                 }
 
@@ -232,12 +222,41 @@ where
             }
         };
 
-        let inner = Rc::clone(&self.inner);
+        #[cfg(feature = "draft-private-network-access")]
+        let private_network_access_requested = req
+            .headers()
+            .contains_key("access-control-request-private-network");
+        #[cfg(not(feature = "draft-private-network-access"))]
+        let private_network_access_requested = false;
+
         let fut = self.service.call(req);
 
         Box::pin(async move {
-            let res = fut.await;
-            Ok(Self::augment_response(&inner, origin_allowed, res?).map_into_left_body())
+            match fut.await {
+                Ok(mut res) => {
+                    Self::augment_response_headers(
+                        &inner,
+                        allow_origin.clone(),
+                        private_network_access_requested,
+                        res.headers_mut(),
+                    );
+
+                    Ok(res.map_into_left_body())
+                }
+                Err(mut err) => {
+                    err.add_response_mapper(move |mut res| {
+                        Self::augment_response_headers(
+                            &inner,
+                            allow_origin.clone(),
+                            private_network_access_requested,
+                            res.headers_mut(),
+                        );
+                        res
+                    });
+
+                    Err(err)
+                }
+            }
         })
     }
 }

--- a/actix-cors/tests/tests.rs
+++ b/actix-cors/tests/tests.rs
@@ -1,7 +1,7 @@
 use actix_cors::Cors;
 use actix_utils::future::ok;
 use actix_web::{
-    dev::{fn_service, ServiceRequest, Transform},
+    dev::{fn_service, Service, ServiceRequest, ServiceResponse, Transform},
     http::{
         header::{self, HeaderValue},
         Method, StatusCode,
@@ -443,6 +443,48 @@ async fn test_no_origin_response() {
         resp.headers()
             .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
             .map(HeaderValue::as_bytes)
+    );
+}
+
+#[actix_web::test]
+async fn cors_headers_are_added_to_error_responses() {
+    let cors = Cors::permissive()
+        .disable_preflight()
+        .new_transform(fn_service(|_req: ServiceRequest| async {
+            Err::<ServiceResponse, _>(actix_web::error::ErrorBadRequest("error"))
+        }))
+        .await
+        .unwrap();
+
+    let req = TestRequest::get()
+        .insert_header((header::ORIGIN, "https://www.example.com"))
+        .to_srv_request();
+    let err = cors.call(req).await.unwrap_err();
+    let resp = err.error_response();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        resp.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN),
+        Some(&HeaderValue::from_static("https://www.example.com")),
+    );
+    assert_eq!(
+        resp.headers().get(header::ACCESS_CONTROL_ALLOW_CREDENTIALS),
+        Some(&HeaderValue::from_static("true")),
+    );
+    #[cfg(not(feature = "draft-private-network-access"))]
+    assert_eq!(
+        resp.headers().get(header::VARY),
+        Some(&HeaderValue::from_static(
+            "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+        )),
+    );
+    #[cfg(feature = "draft-private-network-access")]
+    assert_eq!(
+        resp.headers().get(header::VARY),
+        Some(&HeaderValue::from_static(
+            "Origin, Access-Control-Request-Method, Access-Control-Request-Headers, \
+            Access-Control-Request-Private-Network",
+        )),
     );
 }
 


### PR DESCRIPTION
## Summary

- Require Actix Web 4.15 and use Error::add_response_mapper for propagated errors.
- Apply the configured CORS response headers to error responses as well as successful responses.
- Add regression coverage for origin, credentials, Vary, and the private-network feature mode.

## Testing

- cargo test -p actix-cors --all-features --locked
- just check
- just clippy (passes with existing unrelated warnings)