### PR TITLE
ci: move cargo deny checks to lint workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,6 @@ jobs:
         if: matrix.version.name == 'msrv'
         run: just downgrade-for-msrv
 
-      - name: deny check
-        if: matrix.version.name == 'stable' && matrix.target.os == 'ubuntu-latest'
-        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
-
       - name: check minimal
         run: cargo ci-min
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,18 @@ jobs:
           annotations: true
           version: v1.24.1
 
+  deny:
+    name: deny
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: deny check
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
+
   fmt:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- move the cargo-deny check from the CI test matrix to a dedicated lint job

## Validation

- Ruby YAML parsing
- Prettier workflow check