### PR TITLE
implement in-memory limiter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,13 @@ jobs:
         timeout-minutes: 40
         run: cargo ci-test --exclude=actix-session --exclude=actix-limitation
 
+      # actix-limitation is excluded above because its Redis-backed tests need a
+      # service container, which is not available on macOS/Windows runners. The
+      # in-memory store needs no external service, so those tests can run here.
+      - name: tests (actix-limitation, memory store)
+        timeout-minutes: 10
+        run: cargo test -p actix-limitation --features memory-store --test memory
+
       - name: tests (actix-settings)
         timeout-minutes: 40
         run: just ci-test-actix-settings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,11 +121,13 @@ dependencies = [
 name = "actix-limitation"
 version = "0.6.0"
 dependencies = [
+ "actix-limitation",
  "actix-session",
  "actix-utils",
  "actix-web",
  "chrono",
  "derive_more",
+ "env_logger",
  "log",
  "redis",
  "static_assertions",

--- a/actix-limitation/CHANGES.md
+++ b/actix-limitation/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Add `memory-store` crate feature (off-by-default) which enables a process-local, in-memory counter store.
+- Add `MemoryStore` and `MemoryStoreBuilder` types.
+- Add `Limiter::memory_builder()` constructor for building a limiter backed by a `MemoryStore`.
+- Add `memory` example, runnable with no Redis server, and `redis` example.
+
 ## 0.6.0
 
 - Update `redis` dependency to `1`.

--- a/actix-limitation/Cargo.toml
+++ b/actix-limitation/Cargo.toml
@@ -5,8 +5,8 @@ authors = [
     "0xmad <0xmad@users.noreply.github.com>",
     "Rob Ede <robjtede@icloud.com>",
 ]
-description = "Rate limiter using a fixed window counter for arbitrary keys, backed by Redis for Actix Web"
-keywords = ["actix-web", "rate-api", "rate-limit", "limitation"]
+description = "Rate limiter using a fixed window counter for arbitrary keys, backed by Redis or an in-memory store, for Actix Web"
+keywords = ["actix-web", "rate-api", "rate-limit", "limitation", "in-memory"]
 categories = ["asynchronous", "web-programming"]
 repository = "https://github.com/actix/actix-extras"
 license.workspace = true
@@ -19,6 +19,7 @@ all-features = true
 [features]
 default = ["session"]
 session = ["actix-session"]
+memory-store = []
 redis-native-tls = ["redis/tokio-native-tls-comp"]
 redis-rustls = ["redis/tokio-rustls-comp"]
 
@@ -36,9 +37,15 @@ time = "0.3"
 actix-session = { version = "0.11", optional = true }
 
 [dev-dependencies]
+actix-limitation = { path = ".", features = ["memory-store"] }
 actix-web = "4"
+env_logger = "0.11"
 static_assertions = "1"
 uuid = { version = "1", features = ["v4"] }
 
 [lints]
 workspace = true
+
+[[example]]
+name = "memory"
+required-features = ["memory-store"]

--- a/actix-limitation/README.md
+++ b/actix-limitation/README.md
@@ -1,6 +1,6 @@
 # actix-limitation
 
-> Rate limiter using a fixed window counter for arbitrary keys, backed by Redis for Actix Web.  
+> Rate limiter using a fixed window counter for arbitrary keys, backed by Redis or an in-memory store, for Actix Web.  
 > Originally based on <https://github.com/fnichol/limitation>.
 
 <!-- prettier-ignore-start -->
@@ -12,12 +12,48 @@
 
 <!-- prettier-ignore-end -->
 
+## Backends
+
+Counters are kept in a store, and a `Limiter` is bound to exactly one of them, chosen when it is constructed.
+
+- **Redis**, via `Limiter::builder(redis_url)`. Counters are shared by every instance of your application. The `redis` crate is a required dependency, so this backend needs no feature flag and is the default choice.
+
+  ```console
+  cargo add actix-limitation
+  ```
+
+  Add the `redis-native-tls` feature flag to connect to Redis over a secure connection using `native-tls`, or `redis-rustls` to depend on `rustls` instead:
+
+  ```console
+  cargo add actix-limitation --features=redis-native-tls
+  ```
+
+- **In-memory**, via `Limiter::memory_builder(MemoryStore::new())`, behind the off-by-default `memory-store` feature flag. It needs no server at all, which makes it the zero-setup choice for local development, examples, and tests. Counters are process-local: they are not shared between instances and are lost on restart, so running N instances makes the effective limit `limit × N`. It is a real implementation, not a stub, and is safe in production on a single instance; see the [`MemoryStore` docs](https://docs.rs/actix-limitation/latest/actix_limitation/struct.MemoryStore.html) for the full caveats.
+
+  ```console
+  cargo add actix-limitation --features=memory-store
+  ```
+
+The bundled examples are the quickest way to try either backend. The in-memory one needs nothing installed:
+
+```console
+cargo run --example memory --features memory-store
+curl -i localhost:8080 # 200 five times, then 429
+```
+
+The Redis one is the same app with one line changed, and needs a server:
+
+```console
+docker run --rm -p 6379:6379 redis:8
+cargo run --example redis
+```
+
 ## Examples
 
 ```toml
 [dependencies]
 actix-web = "4"
-actix-limitation = "0.5"
+actix-limitation = "0.6"
 ```
 
 ```rust
@@ -50,6 +86,39 @@ async fn main() -> std::io::Result<()> {
             .wrap(RateLimiter::default())
             .app_data(limiter.clone())
             .service(index)
+    })
+    .bind(("127.0.0.1", 8080))?
+    .run()
+    .await
+}
+```
+
+Rate limiting by peer IP with no Redis server to run, using the `memory-store` feature:
+
+```rust
+use actix_limitation::{Limiter, MemoryStore, RateLimiter};
+use actix_web::{dev::ServiceRequest, web, App, HttpServer};
+use std::time::Duration;
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    // Build the limiter once, outside the `HttpServer::new` closure, then clone the `web::Data`
+    // handle into each worker. The closure runs once per worker thread, so building the limiter
+    // inside it would give every worker its own store and silently multiply the effective limit.
+    let limiter = web::Data::new(
+        Limiter::memory_builder(MemoryStore::new())
+            .key_by(|req: &ServiceRequest| req.connection_info().peer_addr().map(str::to_owned))
+            .limit(5)
+            .period(Duration::from_secs(10))
+            .build()
+            .unwrap(),
+    );
+
+    HttpServer::new(move || {
+        App::new()
+            .wrap(RateLimiter::default())
+            .app_data(limiter.clone())
+            .default_service(web::to(|| async { "Hello!" }))
     })
     .bind(("127.0.0.1", 8080))?
     .run()

--- a/actix-limitation/examples/memory.rs
+++ b/actix-limitation/examples/memory.rs
@@ -1,0 +1,86 @@
+//! Rate limiting with the in-memory store — no Redis, no other service required.
+//!
+//! Run it:
+//!
+//! ```console
+//! cargo run --example memory --features memory-store
+//! curl -i localhost:8080     # 200 five times, then 429
+//! ```
+//!
+//! The limit is 5 requests per 10 seconds per client IP, so you can also exhaust it by refreshing
+//! <http://localhost:8080> in a browser and then watch it recover once the window rolls over.
+//!
+//! Requests are keyed on the client's socket address, so each client gets its own counter.
+//!
+//! See `examples/redis.rs` for the same app backed by Redis instead.
+
+use std::{
+    sync::atomic::{AtomicUsize, Ordering},
+    time::Duration,
+};
+
+use actix_limitation::{Limiter, MemoryStore, RateLimiter};
+use actix_web::{dev::ServiceRequest, get, middleware, web, App, HttpServer, Responder};
+
+const LIMIT: usize = 5;
+const PERIOD: Duration = Duration::from_secs(10);
+
+/// Counts requests that made it past the rate limiter, so the limit is visible in the response.
+#[derive(Debug, Default)]
+struct Served(AtomicUsize);
+
+#[get("/")]
+async fn index(served: web::Data<Served>) -> impl Responder {
+    let n = served.0.fetch_add(1, Ordering::Relaxed) + 1;
+
+    format!(
+        "OK — request {n} served (limit: {LIMIT} requests per {}s per client IP)\n",
+        PERIOD.as_secs(),
+    )
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    // Initialise logging before the store is built, or its startup warning is dropped.
+    env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
+
+    // Both backends can be compiled in at once, so a real app can pick one at startup from its
+    // configuration — in-memory in development, Redis in production:
+    //
+    //     let mut builder = match env::var("REDIS_URL") {
+    //         Ok(url) => Limiter::builder(url),
+    //         Err(_) => Limiter::memory_builder(MemoryStore::new()),
+    //     };
+    let limiter = Limiter::memory_builder(MemoryStore::new())
+        // Without an explicit key the default derives one from a session or cookie; a bare `curl`
+        // has neither, and the middleware lets a `None` key through *unlimited*.
+        //
+        // `peer_addr` cannot be forged. `realip_remote_addr` trusts `X-Forwarded-For` instead, so
+        // use it only behind a proxy you control — otherwise a client mints a fresh quota per
+        // request.
+        .key_by(|req: &ServiceRequest| req.connection_info().peer_addr().map(str::to_owned))
+        .limit(LIMIT)
+        .period(PERIOD)
+        .build()
+        .expect("limiter should build");
+
+    // Build the limiter *once*, out here: the `HttpServer::new` closure runs per worker thread, so
+    // building it inside would give each worker its own store and multiply the effective limit.
+    let limiter = web::Data::new(limiter);
+    let served = web::Data::new(Served::default());
+
+    log::info!("starting HTTP server at http://localhost:8080");
+
+    HttpServer::new(move || {
+        App::new()
+            .wrap(middleware::Logger::default())
+            .wrap(RateLimiter::default())
+            .app_data(limiter.clone())
+            .app_data(served.clone())
+            .service(index)
+    })
+    .bind(("127.0.0.1", 8080))?
+    .workers(2)
+    .run()
+    .await
+}

--- a/actix-limitation/examples/redis.rs
+++ b/actix-limitation/examples/redis.rs
@@ -1,0 +1,88 @@
+//! Rate limiting with the Redis store — counters shared by every instance of the app.
+//!
+//! Start a Redis server, then run it:
+//!
+//! ```console
+//! docker run --rm -p 6379:6379 redis:8
+//! cargo run --example redis
+//! curl -i localhost:8080     # 200 five times, then 429
+//! ```
+//!
+//! Set `REDIS_URL` to point somewhere other than `redis://127.0.0.1:6379`.
+//!
+//! The limit is 5 requests per 10 seconds per client IP, so you can also exhaust it by refreshing
+//! <http://localhost:8080> in a browser and then watch it recover once the window rolls over.
+//! Because the counters live in Redis they survive a restart of this process, and a second copy of
+//! the app on another port shares the same quota — run one and see.
+//!
+//! See `examples/memory.rs` for the same app with no server to run at all.
+
+use std::{
+    env,
+    sync::atomic::{AtomicUsize, Ordering},
+    time::Duration,
+};
+
+use actix_limitation::{Limiter, RateLimiter};
+use actix_web::{dev::ServiceRequest, get, middleware, web, App, HttpServer, Responder};
+
+const LIMIT: usize = 5;
+const PERIOD: Duration = Duration::from_secs(10);
+const DEFAULT_REDIS_URL: &str = "redis://127.0.0.1:6379";
+
+/// Counts requests that made it past the rate limiter, so the limit is visible in the response.
+#[derive(Debug, Default)]
+struct Served(AtomicUsize);
+
+#[get("/")]
+async fn index(served: web::Data<Served>) -> impl Responder {
+    let n = served.0.fetch_add(1, Ordering::Relaxed) + 1;
+
+    format!(
+        "OK — request {n} served (limit: {LIMIT} requests per {}s per client IP)\n",
+        PERIOD.as_secs(),
+    )
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
+
+    let redis_url = env::var("REDIS_URL").unwrap_or_else(|_| DEFAULT_REDIS_URL.to_owned());
+    log::info!("rate limiting via Redis at {redis_url}");
+
+    // `build` only parses the URL; nothing connects to Redis until the first request is counted, so
+    // a server that is down shows up as a 500 per request rather than as a failure to start.
+    let limiter = Limiter::builder(redis_url)
+        // Without an explicit key the default derives one from a session or cookie; a bare `curl`
+        // has neither, and the middleware lets a `None` key through *unlimited*.
+        //
+        // `peer_addr` cannot be forged. `realip_remote_addr` trusts `X-Forwarded-For` instead, so
+        // use it only behind a proxy you control — otherwise a client mints a fresh quota per
+        // request.
+        .key_by(|req: &ServiceRequest| req.connection_info().peer_addr().map(str::to_owned))
+        .limit(LIMIT)
+        .period(PERIOD)
+        .build()
+        .expect("limiter should build");
+
+    // Build the limiter *once*, out here: the `HttpServer::new` closure runs per worker thread, so
+    // building it inside would give each worker its own store and multiply the effective limit.
+    let limiter = web::Data::new(limiter);
+    let served = web::Data::new(Served::default());
+
+    log::info!("starting HTTP server at http://localhost:8080");
+
+    HttpServer::new(move || {
+        App::new()
+            .wrap(middleware::Logger::default())
+            .wrap(RateLimiter::default())
+            .app_data(limiter.clone())
+            .app_data(served.clone())
+            .service(index)
+    })
+    .bind(("127.0.0.1", 8080))?
+    .workers(2)
+    .run()
+    .await
+}

--- a/actix-limitation/src/builder.rs
+++ b/actix-limitation/src/builder.rs
@@ -5,12 +5,25 @@ use actix_session::SessionExt as _;
 use actix_web::dev::ServiceRequest;
 use redis::Client;
 
-use crate::{errors::Error, GetArcBoxKeyFn, Limiter};
+#[cfg(feature = "memory-store")]
+use crate::store::MemoryStore;
+use crate::{errors::Error, store::Backend, GetArcBoxKeyFn, Limiter};
+
+/// The backend a [`Builder`] will construct, before it is resolved into a [`Backend`].
+#[derive(Debug, Clone)]
+pub(crate) enum BackendSpec {
+    /// A Redis connection URL, parsed into a client by [`Builder::build`].
+    RedisUrl(String),
+
+    /// An already-constructed in-memory store.
+    #[cfg(feature = "memory-store")]
+    Memory(MemoryStore),
+}
 
 /// Rate limiter builder.
 #[derive(Debug)]
 pub struct Builder {
-    pub(crate) redis_url: String,
+    pub(crate) backend: BackendSpec,
     pub(crate) limit: usize,
     pub(crate) period: Duration,
     pub(crate) get_key_fn: Option<GetArcBoxKeyFn>,
@@ -70,8 +83,8 @@ impl Builder {
 
     /// Finalizes and returns a `Limiter`.
     ///
-    /// Note that this method will connect to the Redis server to test its connection which is a
-    /// **synchronous** operation.
+    /// For the Redis backend, the URL is parsed here; no connection is established until the first
+    /// request is counted. An invalid URL is therefore reported as an error by this method.
     pub fn build(&mut self) -> Result<Limiter, Error> {
         let get_key = if let Some(resolver) = self.get_key_fn.clone() {
             resolver
@@ -96,8 +109,15 @@ impl Builder {
             closure
         };
 
+        let backend = match &self.backend {
+            BackendSpec::RedisUrl(url) => Backend::Redis(Client::open(url.as_str())?),
+
+            #[cfg(feature = "memory-store")]
+            BackendSpec::Memory(store) => Backend::Memory(store.clone()),
+        };
+
         Ok(Limiter {
-            client: Client::open(self.redis_url.as_str())?,
+            backend,
             limit: self.limit,
             period: self.period,
             get_key_fn: get_key,
@@ -114,7 +134,7 @@ mod tests {
         let redis_url = "redis://127.0.0.1";
         let period = Duration::from_secs(10);
         let builder = Builder {
-            redis_url: redis_url.to_owned(),
+            backend: BackendSpec::RedisUrl(redis_url.to_owned()),
             limit: 100,
             period,
             get_key_fn: Some(Arc::new(|_| None)),
@@ -123,7 +143,12 @@ mod tests {
             session_key: Cow::Owned("rate-api".to_string()),
         };
 
-        assert_eq!(builder.redis_url, redis_url);
+        match &builder.backend {
+            BackendSpec::RedisUrl(url) => assert_eq!(url, redis_url),
+
+            #[cfg(feature = "memory-store")]
+            BackendSpec::Memory(_) => panic!("expected a Redis backend"),
+        }
         assert_eq!(builder.limit, 100);
         assert_eq!(builder.period, period);
         #[cfg(feature = "session")]
@@ -136,7 +161,7 @@ mod tests {
         let redis_url = "redis://127.0.0.1";
         let period = Duration::from_secs(20);
         let mut builder = Builder {
-            redis_url: redis_url.to_owned(),
+            backend: BackendSpec::RedisUrl(redis_url.to_owned()),
             limit: 100,
             period: Duration::from_secs(10),
             get_key_fn: Some(Arc::new(|_| None)),
@@ -157,7 +182,7 @@ mod tests {
         let redis_url = "127.0.0.1";
         let period = Duration::from_secs(20);
         let mut builder = Builder {
-            redis_url: redis_url.to_owned(),
+            backend: BackendSpec::RedisUrl(redis_url.to_owned()),
             limit: 100,
             period: Duration::from_secs(10),
             get_key_fn: Some(Arc::new(|_| None)),

--- a/actix-limitation/src/lib.rs
+++ b/actix-limitation/src/lib.rs
@@ -1,10 +1,50 @@
-//! Rate limiter using a fixed window counter for arbitrary keys, backed by Redis for Actix Web.
+//! Rate limiter using a fixed window counter for arbitrary keys, backed by Redis or an in-memory
+//! store, for Actix Web.
 //!
 //! ```toml
 //! [dependencies]
 //! actix-web = "4"
 #![doc = concat!("actix-limitation = \"", env!("CARGO_PKG_VERSION_MAJOR"), ".", env!("CARGO_PKG_VERSION_MINOR"),"\"")]
 //! ```
+//!
+//! # Choosing A Backend
+//!
+//! Counters are kept in a store, and a [`Limiter`] is bound to exactly one of them, chosen when it
+//! is constructed. You can use:
+//!
+//! - a Redis-backed store, shared by every instance of your application, via [`Limiter::builder()`].
+//!   The [`redis`] crate is a required dependency, so this backend needs no feature flag and is the
+//!   default choice.
+//!
+//!   ```console
+//!   cargo add actix-limitation
+//!   ```
+//!
+//!   Add the `redis-native-tls` feature flag if you want to connect to Redis using a secure
+//!   connection (via the `native-tls` crate):
+//!
+//!   ```console
+//!   cargo add actix-limitation --features=redis-native-tls
+//!   ```
+//!
+//!   If you, instead, prefer depending on `rustls`, use the `redis-rustls` feature flag:
+//!
+//!   ```console
+//!   cargo add actix-limitation --features=redis-rustls
+//!   ```
+//!
+//! - a process-local, in-memory store, [`MemoryStore`], via [`Limiter::memory_builder()`], using the
+//!   `memory-store` feature flag. It needs no server at all, which makes it the zero-setup choice
+//!   for local development, examples, and tests. Counters are not shared between instances, so read
+//!   [`MemoryStore`] before reaching for it in production.
+//!
+//!   ```console
+//!   cargo add actix-limitation --features=memory-store
+//!   ```
+//!
+//! # Examples
+//!
+//! Rate limiting with Redis, keyed by session ID:
 //!
 //! ```no_run
 //! use std::{sync::Arc, time::Duration};
@@ -19,6 +59,8 @@
 //!
 //! #[actix_web::main]
 //! async fn main() -> std::io::Result<()> {
+//!     // Build the limiter once, outside the `HttpServer::new` closure, and clone the `web::Data`
+//!     // handle into each worker; see the note on sharing below.
 //!     let limiter = web::Data::new(
 //!         Limiter::builder("redis://127.0.0.1")
 //!             .key_by(|req: &ServiceRequest| {
@@ -43,6 +85,55 @@
 //!     .await
 //! }
 //! ```
+//!
+//! The same app rate limited by peer IP with no Redis server to run, using the `memory-store`
+//! feature. Try it with `cargo run --example memory --features memory-store`.
+//!
+//! ```no_run
+//! use std::time::Duration;
+//! use actix_web::{dev::ServiceRequest, get, web, App, HttpServer, Responder};
+//! use actix_limitation::{Limiter, MemoryStore, RateLimiter};
+//!
+//! #[get("/")]
+//! async fn index() -> impl Responder {
+//!     "Hello!"
+//! }
+//!
+//! #[actix_web::main]
+//! async fn main() -> std::io::Result<()> {
+//!     // Build the limiter once, HERE, outside the `HttpServer::new` closure. The closure runs once
+//!     // per worker thread, so constructing the limiter inside it would give every worker its own
+//!     // set of counters and silently multiply the effective limit by the worker count. Cloning the
+//!     // `web::Data` handle into each worker shares one store instead.
+//!     let limiter = web::Data::new(
+//!         Limiter::memory_builder(MemoryStore::new())
+//!             .key_by(|req: &ServiceRequest| {
+//!                 // `peer_addr` is the socket address, so unlike `realip_remote_addr` it cannot
+//!                 // be spoofed with a forwarding header. Behind a trusted proxy, use the latter.
+//!                 req.connection_info().peer_addr().map(str::to_owned)
+//!             })
+//!             .limit(5)
+//!             .period(Duration::from_secs(10))
+//!             .build()
+//!             .unwrap(),
+//!     );
+//!
+//!     HttpServer::new(move || {
+//!         App::new()
+//!             .wrap(RateLimiter::default())
+//!             .app_data(limiter.clone())
+//!             .service(index)
+//!     })
+//!     .bind(("127.0.0.1", 8080))?
+//!     .run()
+//!     .await
+//! }
+//! ```
+//!
+//! [`redis`]: https://docs.rs/redis
+//! [`Limiter::builder()`]: Limiter::builder
+//! [`Limiter::memory_builder()`]: Limiter::memory_builder
+//! [`MemoryStore`]: crate::MemoryStore
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs, missing_debug_implementations)]
@@ -53,13 +144,17 @@
 use std::{borrow::Cow, fmt, sync::Arc, time::Duration};
 
 use actix_web::dev::ServiceRequest;
-use redis::{AsyncConnectionConfig, Client};
 
 mod builder;
 mod errors;
 mod middleware;
 mod status;
+mod store;
 
+#[cfg(feature = "memory-store")]
+#[cfg_attr(docsrs, doc(cfg(feature = "memory-store")))]
+pub use self::store::{MemoryStore, MemoryStoreBuilder};
+use self::{builder::BackendSpec, store::Backend};
 pub use self::{builder::Builder, errors::Error, middleware::RateLimiter, status::Status};
 
 /// Default request limit.
@@ -96,7 +191,7 @@ type GetArcBoxKeyFn = Arc<GetKeyFn>;
 /// Rate limiter.
 #[derive(Debug, Clone)]
 pub struct Limiter {
-    client: Client,
+    backend: Backend,
     limit: usize,
     period: Duration,
     get_key_fn: GetArcBoxKeyFn,
@@ -110,7 +205,28 @@ impl Limiter {
     #[must_use]
     pub fn builder(redis_url: impl Into<String>) -> Builder {
         Builder {
-            redis_url: redis_url.into(),
+            backend: BackendSpec::RedisUrl(redis_url.into()),
+            limit: DEFAULT_REQUEST_LIMIT,
+            period: Duration::from_secs(DEFAULT_PERIOD_SECS),
+            get_key_fn: None,
+            cookie_name: Cow::Borrowed(DEFAULT_COOKIE_NAME),
+            #[cfg(feature = "session")]
+            session_key: Cow::Borrowed(DEFAULT_SESSION_KEY),
+        }
+    }
+
+    /// Construct rate limiter builder backed by the given in-memory store.
+    ///
+    /// Counters are process-local and are not shared between instances; see [`MemoryStore`] for
+    /// what that means for your deployment.
+    ///
+    /// Pass [`MemoryStore::new()`] for defaults, or [`MemoryStore::builder()`] to configure it.
+    #[cfg(feature = "memory-store")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "memory-store")))]
+    #[must_use]
+    pub fn memory_builder(store: MemoryStore) -> Builder {
+        Builder {
+            backend: BackendSpec::Memory(store),
             limit: DEFAULT_REQUEST_LIMIT,
             period: Duration::from_secs(DEFAULT_PERIOD_SECS),
             get_key_fn: None,
@@ -123,6 +239,7 @@ impl Limiter {
     /// Consumes one rate limit unit, returning the status.
     pub async fn count(&self, key: impl Into<String>) -> Result<Status, Error> {
         let (count, reset) = self.track(key).await?;
+        let reset = Status::epoch_utc_plus(reset)?;
         let status = Status::new(count, self.limit, reset);
 
         if count > self.limit {
@@ -132,40 +249,16 @@ impl Limiter {
         }
     }
 
-    /// Tracks the given key in a period and returns the count and TTL for the key in seconds.
-    async fn track(&self, key: impl Into<String>) -> Result<(usize, usize), Error> {
+    /// Tracks the given key in a period and returns the count and TTL for the key.
+    async fn track(&self, key: impl Into<String>) -> Result<(usize, Duration), Error> {
         let key = key.into();
-        let expires = self.period.as_secs();
 
-        // Keep pre-redis@1 behavior by opting out of default async connection/response timeouts.
-        let connection_config = AsyncConnectionConfig::new()
-            .set_connection_timeout(None)
-            .set_response_timeout(None);
-        let mut connection = self
-            .client
-            .get_multiplexed_async_connection_with_config(&connection_config)
-            .await?;
+        match &self.backend {
+            Backend::Redis(client) => store::redis::track(client, &key, self.period).await,
 
-        // The seed of this approach is outlined Atul R in a blog post about rate limiting using
-        // NodeJS and Redis. For more details, see https://blog.atulr.com/rate-limiter
-        let mut pipe = redis::pipe();
-        pipe.atomic()
-            .cmd("SET") // Set key and value
-            .arg(&key)
-            .arg(0)
-            .arg("EX") // Set the specified expire time, in seconds.
-            .arg(expires)
-            .arg("NX") // Only set the key if it does not already exist.
-            .ignore() // --- ignore returned value of SET command ---
-            .cmd("INCR") // Increment key
-            .arg(&key)
-            .cmd("TTL") // Return time-to-live of key
-            .arg(&key);
-
-        let (count, ttl) = pipe.query_async(&mut connection).await?;
-        let reset = Status::epoch_utc_plus(Duration::from_secs(ttl))?;
-
-        Ok((count, reset))
+            #[cfg(feature = "memory-store")]
+            Backend::Memory(store) => Ok(store.track(&key, self.period)),
+        }
     }
 }
 

--- a/actix-limitation/src/store/memory.rs
+++ b/actix-limitation/src/store/memory.rs
@@ -69,13 +69,9 @@ const DEFAULT_SWEEP_INTERVAL: Duration = Duration::from_secs(60);
 /// Configure the store with [`MemoryStore::builder()`]:
 ///
 /// ```
-/// use std::time::Duration;
 /// use actix_limitation::MemoryStore;
 ///
-/// let store = MemoryStore::builder()
-///     .max_keys(10_000)
-///     .sweep_interval(Duration::from_secs(30))
-///     .build();
+/// let store = MemoryStore::builder().max_keys(10_000).build();
 /// ```
 ///
 /// # Differences From The Redis Backend
@@ -101,9 +97,9 @@ const DEFAULT_SWEEP_INTERVAL: Duration = Duration::from_secs(60);
 /// `HttpServer::new(…)` closure gives each worker thread its own counters. Build it once, outside,
 /// and clone the [`web::Data`] handle in — see the example above.
 ///
-/// Expired counters are removed lazily, by a sweep that runs on a write at most once per
-/// [`sweep_interval`](MemoryStoreBuilder::sweep_interval); there is no background task. Memory use
-/// is therefore proportional to the number of distinct keys seen within a sweep interval, and is
+/// Expired counters are removed lazily, by a sweep that runs on a write at most once a minute;
+/// there is no background task. Memory use is therefore proportional to the number of distinct
+/// keys seen within a sweep interval, and is
 /// unbounded unless [`max_keys`](MemoryStoreBuilder::max_keys) is set — which trades that bound for
 /// failing open, as above.
 ///
@@ -165,27 +161,6 @@ impl MemoryStore {
         MemoryStoreBuilder {
             max_keys: None,
             sweep_interval: DEFAULT_SWEEP_INTERVAL,
-        }
-    }
-
-    /// The single construction path, so the development-only warning is emitted exactly once per
-    /// constructed store.
-    fn from_parts(max_keys: Option<NonZeroUsize>, sweep_interval: Duration) -> Self {
-        log::warn!(
-            "actix-limitation: using the in-memory store; rate limit counters are process-local \
-             and are not shared between instances or preserved across restarts"
-        );
-
-        MemoryStore {
-            inner: Arc::new(Inner {
-                max_keys,
-                sweep_interval,
-                state: Mutex::new(State {
-                    counters: HashMap::new(),
-                    next_sweep: Instant::now() + sweep_interval,
-                    capacity_warned_at: None,
-                }),
-            }),
         }
     }
 
@@ -311,20 +286,33 @@ impl MemoryStoreBuilder {
         self
     }
 
-    /// Sets the minimum interval between sweeps of expired counters. Defaults to 60 seconds.
-    ///
-    /// There is no background task: sweeps run lazily, on a write, at most this often. A zero
-    /// interval therefore sweeps on every write.
-    #[must_use]
-    pub fn sweep_interval(mut self, every: Duration) -> Self {
+    /// Shortens the otherwise fixed [`DEFAULT_SWEEP_INTERVAL`], so sweeping is observable in a
+    /// test without sleeping for a minute.
+    #[cfg(test)]
+    fn sweep_interval(mut self, every: Duration) -> Self {
         self.sweep_interval = every;
         self
     }
 
-    /// Constructs the configured [`MemoryStore`].
+    /// Constructs the configured [`MemoryStore`], warning once that its counters are process-local.
     #[must_use]
     pub fn build(self) -> MemoryStore {
-        MemoryStore::from_parts(self.max_keys, self.sweep_interval)
+        log::warn!(
+            "actix-limitation: using the in-memory store; rate limit counters are process-local \
+             and are not shared between instances or preserved across restarts"
+        );
+
+        MemoryStore {
+            inner: Arc::new(Inner {
+                max_keys: self.max_keys,
+                sweep_interval: self.sweep_interval,
+                state: Mutex::new(State {
+                    counters: HashMap::new(),
+                    next_sweep: Instant::now() + self.sweep_interval,
+                    capacity_warned_at: None,
+                }),
+            }),
+        }
     }
 }
 

--- a/actix-limitation/src/store/memory.rs
+++ b/actix-limitation/src/store/memory.rs
@@ -1,0 +1,500 @@
+use std::{
+    collections::HashMap,
+    fmt,
+    num::NonZeroUsize,
+    sync::{Arc, Mutex, PoisonError, TryLockError},
+    time::{Duration, Instant},
+};
+
+/// Default interval between lazy sweeps of expired counters.
+const DEFAULT_SWEEP_INTERVAL: Duration = Duration::from_secs(60);
+
+/// A process-local, in-memory rate limit store.
+///
+/// **Counters live in this process only.** They are not shared with any other instance of your
+/// application, and they are lost on restart. Run more than one instance — several pods, several
+/// hosts, or a rolling deploy — and each keeps its own counts, so a client can be served by any of
+/// them and the effective limit becomes `limit × instances`. Restarting an instance resets every
+/// counter it held, letting clients that were over their limit start again immediately.
+///
+/// It is intended for local development, examples, and tests — none of which should need a Redis
+/// server — and is a real implementation, not a stub: on a single instance it is correct, and safe
+/// in production. Reach for [`Limiter::builder()`](crate::Limiter::builder) and Redis as soon as
+/// there is more than one instance to share counts between.
+///
+/// A store is constructed once and cloned; cloning is cheap and all clones share one set of
+/// counters. Constructing one logs a warning at `WARN` level, so an in-memory store shipped to
+/// production by accident is visible in the logs.
+///
+/// The window is fixed, not sliding, matching the Redis backend: the first request for a key opens
+/// a window of [`period`](crate::Builder::period), and later requests inside that window increment
+/// the counter without extending it.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::time::Duration;
+/// use actix_web::{dev::ServiceRequest, web, App, HttpServer};
+/// use actix_limitation::{Limiter, MemoryStore, RateLimiter};
+///
+/// #[actix_web::main]
+/// async fn main() -> std::io::Result<()> {
+///     // Build the limiter ONCE, here, outside the `HttpServer::new` closure, then clone the
+///     // `web::Data` handle into each worker. The closure runs once per worker thread: building the
+///     // limiter inside it would give every worker its own store, so nothing is shared and the
+///     // effective limit is silently multiplied by the worker count.
+///     let limiter = web::Data::new(
+///         Limiter::memory_builder(MemoryStore::new())
+///             .key_by(|req: &ServiceRequest| {
+///                 req.connection_info().peer_addr().map(str::to_owned)
+///             })
+///             .limit(5)
+///             .period(Duration::from_secs(10))
+///             .build()
+///             .unwrap(),
+///     );
+///
+///     HttpServer::new(move || {
+///         App::new()
+///             .wrap(RateLimiter::default())
+///             .app_data(limiter.clone())
+///             .default_service(web::to(|| async { "Hello!" }))
+///     })
+///     .bind(("127.0.0.1", 8080))?
+///     .run()
+///     .await
+/// }
+/// ```
+///
+/// Configure the store with [`MemoryStore::builder()`]:
+///
+/// ```
+/// use std::time::Duration;
+/// use actix_limitation::MemoryStore;
+///
+/// let store = MemoryStore::builder()
+///     .max_keys(10_000)
+///     .sweep_interval(Duration::from_secs(30))
+///     .build();
+/// ```
+///
+/// # Differences From The Redis Backend
+///
+/// Rate limiting semantics are otherwise the same, but two behaviours differ, so that "works
+/// locally, differs in production" does not come as a surprise:
+///
+/// - **Sub-second periods.** This store honours a [`period`](crate::Builder::period) of any
+///   resolution. The Redis backend truncates it with [`Duration::as_secs`], so a period under one
+///   second becomes `SET … EX 0`, which Redis rejects as an invalid expire time. Keep periods at
+///   whole seconds if the same configuration has to run against both backends.
+/// - **Behaviour at capacity.** With [`max_keys`](MemoryStoreBuilder::max_keys) set, this store
+///   fails open: once it is full, a new key is not tracked at all and its requests pass unlimited.
+///   Redis instead applies its own `maxmemory-policy`, which evicts existing counters — resetting
+///   the windows of clients already being tracked — rather than letting new keys through.
+///
+/// # Limitations
+///
+/// Counters are process-local, as above: no sharing between instances, and no persistence across
+/// restarts. Both are inherent, not bugs to be worked around.
+///
+/// Because the store is per-process, a [`Limiter`](crate::Limiter) built inside the
+/// `HttpServer::new(…)` closure gives each worker thread its own counters. Build it once, outside,
+/// and clone the [`web::Data`] handle in — see the example above.
+///
+/// Expired counters are removed lazily, by a sweep that runs on a write at most once per
+/// [`sweep_interval`](MemoryStoreBuilder::sweep_interval); there is no background task. Memory use
+/// is therefore proportional to the number of distinct keys seen within a sweep interval, and is
+/// unbounded unless [`max_keys`](MemoryStoreBuilder::max_keys) is set — which trades that bound for
+/// failing open, as above.
+///
+/// # Exclusivity
+///
+/// The `memory-store` and Redis backends may be compiled in at the same time, on purpose. **This
+/// must not be "fixed" into a `compile_error!` on the combination.** It is not an oversight:
+///
+/// - A [`Limiter`](crate::Limiter) holds exactly one backend, fixed at construction by the
+///   constructor used — [`Limiter::builder()`](crate::Limiter::builder) or
+///   [`Limiter::memory_builder()`](crate::Limiter::memory_builder) — and [`Builder`](crate::Builder)
+///   offers no way to change or add one afterwards. Using two backends at once is therefore not
+///   merely discouraged, it is unrepresentable: no sequence of calls that compiles produces such a
+///   limiter, so no runtime guard or feature-flag exclusion is needed.
+/// - Mutually exclusive features would break the `--all-features` builds this crate relies on: the
+///   docs.rs build (`all-features = true`), `cargo ci-test` and the `--all-features` clippy job.
+/// - Cargo features are additive by contract. A `compile_error!` on the combination makes downstream
+///   dependency graphs unbuildable through feature unification whenever two unrelated crates each
+///   enable a different backend, with no recourse for the end user.
+/// - It keeps backend selection at startup possible — memory locally, Redis in production, chosen
+///   from configuration — which requires both to be compiled in.
+///
+/// [`web::Data`]: actix_web::web::Data
+#[derive(Clone)]
+pub struct MemoryStore {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    max_keys: Option<NonZeroUsize>,
+    sweep_interval: Duration,
+    state: Mutex<State>,
+}
+
+struct State {
+    counters: HashMap<String, Counter>,
+    next_sweep: Instant,
+    capacity_warned_at: Option<Instant>,
+}
+
+#[derive(Clone, Copy)]
+struct Counter {
+    count: usize,
+    expires_at: Instant,
+}
+
+impl MemoryStore {
+    /// Constructs an in-memory store with defaults: unbounded, swept every 60 seconds.
+    ///
+    /// Use [`MemoryStore::builder()`] to configure it.
+    #[must_use]
+    pub fn new() -> Self {
+        MemoryStore::builder().build()
+    }
+
+    /// Constructs an in-memory store builder with defaults.
+    #[must_use]
+    pub fn builder() -> MemoryStoreBuilder {
+        MemoryStoreBuilder {
+            max_keys: None,
+            sweep_interval: DEFAULT_SWEEP_INTERVAL,
+        }
+    }
+
+    /// The single construction path, so the development-only warning is emitted exactly once per
+    /// constructed store.
+    fn from_parts(max_keys: Option<NonZeroUsize>, sweep_interval: Duration) -> Self {
+        log::warn!(
+            "actix-limitation: using the in-memory store; rate limit counters are process-local \
+             and are not shared between instances or preserved across restarts"
+        );
+
+        MemoryStore {
+            inner: Arc::new(Inner {
+                max_keys,
+                sweep_interval,
+                state: Mutex::new(State {
+                    counters: HashMap::new(),
+                    next_sweep: Instant::now() + sweep_interval,
+                    capacity_warned_at: None,
+                }),
+            }),
+        }
+    }
+
+    /// Tracks the given key in a period, returning the count and the time left in its window.
+    ///
+    /// Synchronous: there is no I/O to await.
+    pub(crate) fn track(&self, key: &str, period: Duration) -> (usize, Duration) {
+        let now = Instant::now();
+
+        let mut state = self
+            .inner
+            .state
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+
+        if now >= state.next_sweep {
+            state.counters.retain(|_, counter| counter.expires_at > now);
+            state.next_sweep = now + self.inner.sweep_interval;
+        }
+
+        let counter = state.counters.get(key).copied();
+
+        let start_new_window = counter.is_none_or(|counter| counter.expires_at <= now);
+
+        if counter.is_none() {
+            if let Some(max_keys) = self.inner.max_keys {
+                if state.counters.len() >= max_keys.get() {
+                    state.counters.retain(|_, counter| counter.expires_at > now);
+                    state.next_sweep = now + self.inner.sweep_interval;
+
+                    if state.counters.len() >= max_keys.get() {
+                        let warn = state.capacity_warned_at.is_none_or(|at| {
+                            now.saturating_duration_since(at) >= self.inner.sweep_interval
+                        });
+
+                        if warn {
+                            state.capacity_warned_at = Some(now);
+
+                            log::warn!(
+                                "actix-limitation: in-memory store is at its {} key capacity; new \
+                                 keys are not being rate limited",
+                                max_keys.get(),
+                            );
+                        }
+
+                        return (1, period);
+                    }
+                }
+            }
+        }
+
+        if start_new_window {
+            state.counters.insert(
+                key.to_owned(),
+                Counter {
+                    count: 0,
+                    expires_at: now + period,
+                },
+            );
+        }
+
+        let counter = state
+            .counters
+            .get_mut(key)
+            .expect("counter is either pre-existing or was just inserted");
+
+        counter.count += 1;
+
+        (
+            counter.count,
+            counter.expires_at.saturating_duration_since(now),
+        )
+    }
+}
+
+impl Default for MemoryStore {
+    fn default() -> Self {
+        MemoryStore::new()
+    }
+}
+
+/// Hand-written so that the counters themselves are never dumped; only how many there are.
+impl fmt::Debug for MemoryStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let counters = match self.inner.state.try_lock() {
+            Ok(state) => Some(state.counters.len()),
+            Err(TryLockError::Poisoned(err)) => Some(err.into_inner().counters.len()),
+            Err(TryLockError::WouldBlock) => None,
+        };
+
+        let mut dbg = f.debug_struct("MemoryStore");
+
+        dbg.field("max_keys", &self.inner.max_keys)
+            .field("sweep_interval", &self.inner.sweep_interval);
+
+        match counters {
+            Some(len) => dbg.field("counters", &len),
+            None => dbg.field("counters", &format_args!("<locked>")),
+        };
+
+        dbg.finish()
+    }
+}
+
+/// Builder for [`MemoryStore`].
+#[derive(Debug, Clone)]
+pub struct MemoryStoreBuilder {
+    max_keys: Option<NonZeroUsize>,
+    sweep_interval: Duration,
+}
+
+impl MemoryStoreBuilder {
+    /// Sets the maximum number of keys tracked at once. Unbounded by default.
+    ///
+    /// Expired counters are only removed lazily, so the map can hold more keys than are live. When
+    /// the store is full, a new key forces a sweep; if that frees nothing, the store **fails open**
+    /// — the key is not tracked and the request passes — and warns at most once per sweep interval.
+    ///
+    /// A `max` of `0` is treated as `1`, never as unbounded.
+    #[must_use]
+    pub fn max_keys(mut self, max: usize) -> Self {
+        self.max_keys = Some(NonZeroUsize::new(max).unwrap_or(NonZeroUsize::MIN));
+        self
+    }
+
+    /// Sets the minimum interval between sweeps of expired counters. Defaults to 60 seconds.
+    ///
+    /// There is no background task: sweeps run lazily, on a write, at most this often. A zero
+    /// interval therefore sweeps on every write.
+    #[must_use]
+    pub fn sweep_interval(mut self, every: Duration) -> Self {
+        self.sweep_interval = every;
+        self
+    }
+
+    /// Constructs the configured [`MemoryStore`].
+    #[must_use]
+    pub fn build(self) -> MemoryStore {
+        MemoryStore::from_parts(self.max_keys, self.sweep_interval)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread::sleep;
+
+    use super::*;
+
+    /// Number of counters currently held, expired or not.
+    fn tracked_keys(store: &MemoryStore) -> usize {
+        store.inner.state.lock().unwrap().counters.len()
+    }
+
+    fn is_tracked(store: &MemoryStore, key: &str) -> bool {
+        store.inner.state.lock().unwrap().counters.contains_key(key)
+    }
+
+    #[test]
+    fn defaults() {
+        let store = MemoryStore::new();
+        assert!(store.inner.max_keys.is_none());
+        assert_eq!(store.inner.sweep_interval, DEFAULT_SWEEP_INTERVAL);
+
+        let store = MemoryStore::default();
+        assert!(store.inner.max_keys.is_none());
+    }
+
+    #[test]
+    fn store_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<MemoryStore>();
+        assert_send_sync::<MemoryStoreBuilder>();
+    }
+
+    #[test]
+    fn debug_does_not_dump_counters() {
+        let store = MemoryStore::new();
+        store.track("some-very-distinctive-key", Duration::from_secs(60));
+
+        let repr = format!("{store:?}");
+        assert!(repr.starts_with("MemoryStore"), "{repr}");
+        assert!(!repr.contains("some-very-distinctive-key"), "{repr}");
+        assert!(repr.contains("counters: 1"), "{repr}");
+    }
+
+    #[test]
+    fn counts_increment_within_window() {
+        let store = MemoryStore::new();
+        let period = Duration::from_secs(60);
+
+        for expected in 1..=5 {
+            let (count, reset) = store.track("key", period);
+            assert_eq!(count, expected);
+            assert!(reset <= period);
+        }
+
+        assert_eq!(tracked_keys(&store), 1);
+    }
+
+    #[test]
+    fn window_is_fixed_and_does_not_slide() {
+        let store = MemoryStore::new();
+        let period = Duration::from_millis(300);
+
+        let (count, reset) = store.track("key", period);
+        assert_eq!(count, 1);
+        assert!(reset <= period);
+
+        sleep(Duration::from_millis(80));
+
+        let (count, reset) = store.track("key", period);
+        assert_eq!(count, 2);
+        assert!(
+            reset <= Duration::from_millis(260),
+            "window slid: {reset:?} left of a {period:?} window",
+        );
+
+        sleep(Duration::from_millis(300));
+
+        let (count, reset) = store.track("key", period);
+        assert_eq!(count, 1);
+        assert!(reset > Duration::from_millis(260));
+    }
+
+    #[test]
+    fn distinct_keys_are_independent() {
+        let store = MemoryStore::new();
+        let period = Duration::from_secs(60);
+
+        assert_eq!(store.track("a", period).0, 1);
+        assert_eq!(store.track("a", period).0, 2);
+        assert_eq!(store.track("b", period).0, 1);
+        assert_eq!(store.track("a", period).0, 3);
+        assert_eq!(store.track("b", period).0, 2);
+
+        assert_eq!(tracked_keys(&store), 2);
+    }
+
+    #[test]
+    fn clones_share_counters() {
+        let store = MemoryStore::new();
+        let clone = store.clone();
+
+        assert_eq!(store.track("key", Duration::from_secs(60)).0, 1);
+        assert_eq!(clone.track("key", Duration::from_secs(60)).0, 2);
+    }
+
+    #[test]
+    fn sweep_evicts_expired_entries_only() {
+        let store = MemoryStore::builder()
+            .sweep_interval(Duration::from_millis(50))
+            .build();
+
+        store.track("short", Duration::from_millis(30));
+        store.track("long", Duration::from_secs(60));
+        assert_eq!(tracked_keys(&store), 2);
+
+        sleep(Duration::from_millis(80));
+
+        store.track("trigger", Duration::from_secs(60));
+
+        assert!(!is_tracked(&store, "short"));
+        assert!(is_tracked(&store, "long"));
+        assert!(is_tracked(&store, "trigger"));
+        assert_eq!(tracked_keys(&store), 2);
+
+        assert_eq!(store.track("long", Duration::from_secs(60)).0, 2);
+    }
+
+    #[test]
+    fn full_store_fails_open() {
+        let store = MemoryStore::builder()
+            .max_keys(1)
+            .sweep_interval(Duration::from_secs(60))
+            .build();
+
+        let period = Duration::from_secs(60);
+
+        assert_eq!(store.track("a", period), (1, period));
+
+        assert_eq!(store.track("b", period), (1, period));
+        assert_eq!(store.track("b", period), (1, period));
+        assert!(!is_tracked(&store, "b"));
+        assert_eq!(tracked_keys(&store), 1);
+
+        assert_eq!(store.track("a", period).0, 2);
+    }
+
+    #[test]
+    fn full_store_sweeps_before_failing_open() {
+        let store = MemoryStore::builder()
+            .max_keys(1)
+            .sweep_interval(Duration::from_secs(60))
+            .build();
+
+        store.track("a", Duration::from_millis(30));
+        sleep(Duration::from_millis(50));
+
+        assert_eq!(store.track("b", Duration::from_secs(60)).0, 1);
+        assert!(is_tracked(&store, "b"));
+        assert!(!is_tracked(&store, "a"));
+    }
+
+    #[test]
+    fn max_keys_zero_is_treated_as_one() {
+        let store = MemoryStore::builder().max_keys(0).build();
+        assert_eq!(store.inner.max_keys, NonZeroUsize::new(1));
+
+        assert_eq!(store.track("a", Duration::from_secs(60)).0, 1);
+        assert_eq!(tracked_keys(&store), 1);
+    }
+}

--- a/actix-limitation/src/store/mod.rs
+++ b/actix-limitation/src/store/mod.rs
@@ -1,0 +1,25 @@
+//! Rate limit counter backends.
+
+pub(crate) mod redis;
+
+#[cfg(feature = "memory-store")]
+pub(crate) mod memory;
+
+#[cfg(feature = "memory-store")]
+pub use self::memory::{MemoryStore, MemoryStoreBuilder};
+
+/// The counter store a [`Limiter`](crate::Limiter) is bound to.
+///
+/// A limiter holds exactly one variant, chosen at construction time, so using two backends at once
+/// is unrepresentable.
+// one `Backend` exists per application and is never cloned per request, so the padding is free
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone)]
+pub(crate) enum Backend {
+    /// Counters kept in a Redis server.
+    Redis(::redis::Client),
+
+    /// Counters kept in this process's memory.
+    #[cfg(feature = "memory-store")]
+    Memory(MemoryStore),
+}

--- a/actix-limitation/src/store/redis.rs
+++ b/actix-limitation/src/store/redis.rs
@@ -1,0 +1,44 @@
+//! Redis-backed fixed window counter.
+
+use std::time::Duration;
+
+use redis::{AsyncConnectionConfig, Client};
+
+use crate::errors::Error;
+
+/// Tracks the given key in a period, returning the count and the remaining TTL for the key.
+pub(crate) async fn track(
+    client: &Client,
+    key: &str,
+    period: Duration,
+) -> Result<(usize, Duration), Error> {
+    let expires = period.as_secs();
+
+    // Keep pre-redis@1 behavior by opting out of default async connection/response timeouts.
+    let connection_config = AsyncConnectionConfig::new()
+        .set_connection_timeout(None)
+        .set_response_timeout(None);
+    let mut connection = client
+        .get_multiplexed_async_connection_with_config(&connection_config)
+        .await?;
+
+    // The seed of this approach is outlined Atul R in a blog post about rate limiting using
+    // NodeJS and Redis. For more details, see https://blog.atulr.com/rate-limiter
+    let mut pipe = redis::pipe();
+    pipe.atomic()
+        .cmd("SET") // Set key and value
+        .arg(key)
+        .arg(0)
+        .arg("EX") // Set the specified expire time, in seconds.
+        .arg(expires)
+        .arg("NX") // Only set the key if it does not already exist.
+        .ignore() // --- ignore returned value of SET command ---
+        .cmd("INCR") // Increment key
+        .arg(key)
+        .cmd("TTL") // Return time-to-live of key
+        .arg(key);
+
+    let (count, ttl) = pipe.query_async(&mut connection).await?;
+
+    Ok((count, Duration::from_secs(ttl)))
+}

--- a/actix-limitation/tests/memory.rs
+++ b/actix-limitation/tests/memory.rs
@@ -1,0 +1,324 @@
+#![cfg(feature = "memory-store")]
+
+use std::{thread::sleep, time::Duration};
+
+use actix_limitation::{Error, Limiter, MemoryStore, MemoryStoreBuilder, RateLimiter};
+use actix_web::{
+    dev::ServiceRequest, http::StatusCode, test as actix_test, web, App, HttpRequest, HttpResponse,
+};
+
+const LONG_PERIOD: Duration = Duration::from_secs(60);
+
+const SHORT_PERIOD: Duration = Duration::from_secs(2);
+
+const SHORT_PERIOD_PLUS: Duration = Duration::from_millis(2_500);
+
+fn memory_limiter(limit: usize, period: Duration) -> Limiter {
+    Limiter::memory_builder(MemoryStore::new())
+        .limit(limit)
+        .period(period)
+        .build()
+        .unwrap()
+}
+
+#[test]
+fn memory_store_traits() {
+    static_assertions::assert_impl_all!(MemoryStore: Clone, Default, Send, Sync, std::fmt::Debug);
+    static_assertions::assert_impl_all!(MemoryStoreBuilder: Send, Sync, std::fmt::Debug);
+}
+
+#[test]
+fn memory_store_debug_hides_counters() {
+    let store = MemoryStore::builder()
+        .max_keys(64)
+        .sweep_interval(Duration::from_secs(5))
+        .build();
+
+    let repr = format!("{store:?}");
+
+    assert!(repr.starts_with("MemoryStore"), "{repr}");
+    assert!(repr.contains("counters"), "{repr}");
+}
+
+#[test]
+fn limiter_from_memory_builder_is_infallible() {
+    assert!(Limiter::memory_builder(MemoryStore::new()).build().is_ok());
+    assert!(Limiter::memory_builder(MemoryStore::default())
+        .build()
+        .is_ok());
+    assert!(Limiter::memory_builder(
+        MemoryStore::builder()
+            .max_keys(10)
+            .sweep_interval(Duration::from_secs(1))
+            .build()
+    )
+    .build()
+    .is_ok());
+}
+
+#[actix_web::test]
+async fn test_limiter_count() -> Result<(), Error> {
+    let limit = 20;
+    let limiter = memory_limiter(limit, LONG_PERIOD);
+
+    for i in 0..limit {
+        let status = limiter.count("key").await?;
+        assert_eq!(status.limit(), limit);
+        assert_eq!(limit - status.remaining(), i + 1);
+    }
+
+    Ok(())
+}
+
+#[actix_web::test]
+async fn test_limiter_count_error() -> Result<(), Error> {
+    let limit = 5;
+    let limiter = memory_limiter(limit, LONG_PERIOD);
+
+    for i in 0..limit {
+        let status = limiter.count("key").await?;
+        assert_eq!(limit - status.remaining(), i + 1);
+    }
+
+    for _ in 0..3 {
+        match limiter.count("key").await.unwrap_err() {
+            Error::LimitExceeded(status) => {
+                assert_eq!(status.limit(), limit);
+                assert_eq!(status.remaining(), 0);
+            }
+            err => panic!("error should be LimitExceeded variant, got {err:?}"),
+        }
+    }
+
+    let status = limiter.count("other-key").await?;
+    assert_eq!(status.remaining(), limit - 1);
+
+    Ok(())
+}
+
+#[actix_web::test]
+async fn test_distinct_keys_do_not_interfere() -> Result<(), Error> {
+    let limit = 3;
+    let limiter = memory_limiter(limit, LONG_PERIOD);
+
+    assert_eq!(limiter.count("a").await?.remaining(), 2);
+    assert_eq!(limiter.count("a").await?.remaining(), 1);
+    assert_eq!(limiter.count("b").await?.remaining(), 2);
+    assert_eq!(limiter.count("a").await?.remaining(), 0);
+    assert_eq!(limiter.count("b").await?.remaining(), 1);
+
+    assert!(matches!(
+        limiter.count("a").await.unwrap_err(),
+        Error::LimitExceeded(_),
+    ));
+    assert_eq!(limiter.count("b").await?.remaining(), 0);
+
+    Ok(())
+}
+
+#[actix_web::test]
+async fn test_clones_share_counters() -> Result<(), Error> {
+    let limit = 4;
+
+    let limiter = memory_limiter(limit, LONG_PERIOD);
+    let cloned_limiter = limiter.clone();
+
+    assert_eq!(limiter.count("key").await?.remaining(), 3);
+    assert_eq!(cloned_limiter.count("key").await?.remaining(), 2);
+    assert_eq!(limiter.count("key").await?.remaining(), 1);
+
+    let store = MemoryStore::new();
+    let first = Limiter::memory_builder(store.clone())
+        .limit(limit)
+        .period(LONG_PERIOD)
+        .build()
+        .unwrap();
+    let second = Limiter::memory_builder(store)
+        .limit(limit)
+        .period(LONG_PERIOD)
+        .build()
+        .unwrap();
+
+    assert_eq!(first.count("shared").await?.remaining(), 3);
+    assert_eq!(second.count("shared").await?.remaining(), 2);
+
+    Ok(())
+}
+
+#[actix_web::test]
+async fn test_window_resets_after_period() -> Result<(), Error> {
+    let limit = 5;
+    let limiter = memory_limiter(limit, SHORT_PERIOD);
+
+    assert_eq!(limiter.count("key").await?.remaining(), limit - 1);
+    assert_eq!(limiter.count("key").await?.remaining(), limit - 2);
+
+    sleep(SHORT_PERIOD_PLUS);
+
+    assert_eq!(
+        limiter.count("key").await?.remaining(),
+        limit - 1,
+        "counter did not reset after the window elapsed",
+    );
+
+    Ok(())
+}
+
+#[actix_web::test]
+async fn test_window_does_not_slide() -> Result<(), Error> {
+    let gap = Duration::from_secs(3);
+    let limit = 10;
+    let limiter = memory_limiter(limit, LONG_PERIOD);
+
+    let first = limiter.count("key").await?;
+
+    sleep(gap);
+
+    let second = limiter.count("key").await?;
+
+    assert_eq!(
+        second.remaining(),
+        first.remaining() - 1,
+        "expected the second request to land in the first request's window",
+    );
+
+    assert!(
+        second.reset_epoch_utc() <= first.reset_epoch_utc() + 1,
+        "window slid: reset moved from {} to {} after a {:?} gap",
+        first.reset_epoch_utc(),
+        second.reset_epoch_utc(),
+        gap,
+    );
+
+    Ok(())
+}
+
+#[actix_web::test]
+async fn test_max_keys_fails_open() -> Result<(), Error> {
+    let limiter = Limiter::memory_builder(
+        MemoryStore::builder()
+            .max_keys(1)
+            .sweep_interval(LONG_PERIOD)
+            .build(),
+    )
+    .limit(1)
+    .period(LONG_PERIOD)
+    .build()
+    .unwrap();
+
+    assert_eq!(limiter.count("tracked").await?.remaining(), 0);
+    assert!(matches!(
+        limiter.count("tracked").await.unwrap_err(),
+        Error::LimitExceeded(_),
+    ));
+
+    for key in ["overflow-a", "overflow-b"] {
+        for _ in 0..5 {
+            let status = limiter.count(key).await?;
+            assert_eq!(status.remaining(), 0, "limit is 1, so one unit is consumed");
+        }
+    }
+
+    Ok(())
+}
+
+#[actix_web::test]
+async fn test_middleware_limits_requests() {
+    let limit = 2;
+    let limiter = Limiter::memory_builder(MemoryStore::new())
+        .limit(limit)
+        .period(LONG_PERIOD)
+        .key_by(|_: &ServiceRequest| Some("fixed_key".to_owned()))
+        .build()
+        .unwrap();
+
+    let app = actix_test::init_service(
+        App::new()
+            .wrap(RateLimiter::default())
+            .app_data(web::Data::new(limiter))
+            .route(
+                "/",
+                web::get().to(|_: HttpRequest| async { HttpResponse::Ok().body("ok") }),
+            ),
+    )
+    .await;
+
+    for index in 1..=5 {
+        let req = actix_test::TestRequest::default().to_request();
+        let resp = actix_test::call_service(&app, req).await;
+
+        if index <= limit {
+            assert!(
+                resp.status().is_success(),
+                "request {index}: {:?}",
+                resp.status()
+            );
+        } else {
+            assert_eq!(
+                resp.status(),
+                StatusCode::TOO_MANY_REQUESTS,
+                "request {index}"
+            );
+        }
+    }
+}
+
+#[actix_web::test]
+async fn test_middleware_passes_through_unkeyed_requests() {
+    let app = actix_test::init_service(
+        App::new()
+            .wrap(RateLimiter::default())
+            .app_data(web::Data::new(
+                Limiter::memory_builder(MemoryStore::new())
+                    .limit(1)
+                    .period(LONG_PERIOD)
+                    .key_by(|_: &ServiceRequest| None)
+                    .build()
+                    .unwrap(),
+            ))
+            .route(
+                "/",
+                web::get().to(|_: HttpRequest| async { HttpResponse::Ok().body("ok") }),
+            ),
+    )
+    .await;
+
+    for _ in 0..5 {
+        let req = actix_test::TestRequest::default().to_request();
+        let resp = actix_test::call_service(&app, req).await;
+        assert!(resp.status().is_success());
+    }
+}
+
+#[actix_web::test]
+async fn test_middleware_window_resets() {
+    let limiter = Limiter::memory_builder(MemoryStore::new())
+        .limit(1)
+        .period(SHORT_PERIOD)
+        .key_by(|_: &ServiceRequest| Some("fixed_key".to_owned()))
+        .build()
+        .unwrap();
+
+    let app = actix_test::init_service(
+        App::new()
+            .wrap(RateLimiter::default())
+            .app_data(web::Data::new(limiter))
+            .route(
+                "/",
+                web::get().to(|_: HttpRequest| async { HttpResponse::Ok().body("ok") }),
+            ),
+    )
+    .await;
+
+    let call = || actix_test::call_service(&app, actix_test::TestRequest::default().to_request());
+
+    assert!(call().await.status().is_success());
+    assert_eq!(call().await.status(), StatusCode::TOO_MANY_REQUESTS);
+
+    sleep(SHORT_PERIOD_PLUS);
+
+    assert!(
+        call().await.status().is_success(),
+        "window did not reset for the middleware",
+    );
+}

--- a/actix-limitation/tests/memory.rs
+++ b/actix-limitation/tests/memory.rs
@@ -2,7 +2,7 @@
 
 use std::{thread::sleep, time::Duration};
 
-use actix_limitation::{Error, Limiter, MemoryStore, MemoryStoreBuilder, RateLimiter};
+use actix_limitation::{Error, Limiter, MemoryStore, RateLimiter};
 use actix_web::{
     dev::ServiceRequest, http::StatusCode, test as actix_test, web, App, HttpRequest, HttpResponse,
 };
@@ -19,41 +19,6 @@ fn memory_limiter(limit: usize, period: Duration) -> Limiter {
         .period(period)
         .build()
         .unwrap()
-}
-
-#[test]
-fn memory_store_traits() {
-    static_assertions::assert_impl_all!(MemoryStore: Clone, Default, Send, Sync, std::fmt::Debug);
-    static_assertions::assert_impl_all!(MemoryStoreBuilder: Send, Sync, std::fmt::Debug);
-}
-
-#[test]
-fn memory_store_debug_hides_counters() {
-    let store = MemoryStore::builder()
-        .max_keys(64)
-        .sweep_interval(Duration::from_secs(5))
-        .build();
-
-    let repr = format!("{store:?}");
-
-    assert!(repr.starts_with("MemoryStore"), "{repr}");
-    assert!(repr.contains("counters"), "{repr}");
-}
-
-#[test]
-fn limiter_from_memory_builder_is_infallible() {
-    assert!(Limiter::memory_builder(MemoryStore::new()).build().is_ok());
-    assert!(Limiter::memory_builder(MemoryStore::default())
-        .build()
-        .is_ok());
-    assert!(Limiter::memory_builder(
-        MemoryStore::builder()
-            .max_keys(10)
-            .sweep_interval(Duration::from_secs(1))
-            .build()
-    )
-    .build()
-    .is_ok());
 }
 
 #[actix_web::test]
@@ -97,36 +62,8 @@ async fn test_limiter_count_error() -> Result<(), Error> {
 }
 
 #[actix_web::test]
-async fn test_distinct_keys_do_not_interfere() -> Result<(), Error> {
-    let limit = 3;
-    let limiter = memory_limiter(limit, LONG_PERIOD);
-
-    assert_eq!(limiter.count("a").await?.remaining(), 2);
-    assert_eq!(limiter.count("a").await?.remaining(), 1);
-    assert_eq!(limiter.count("b").await?.remaining(), 2);
-    assert_eq!(limiter.count("a").await?.remaining(), 0);
-    assert_eq!(limiter.count("b").await?.remaining(), 1);
-
-    assert!(matches!(
-        limiter.count("a").await.unwrap_err(),
-        Error::LimitExceeded(_),
-    ));
-    assert_eq!(limiter.count("b").await?.remaining(), 0);
-
-    Ok(())
-}
-
-#[actix_web::test]
-async fn test_clones_share_counters() -> Result<(), Error> {
+async fn test_limiters_share_one_store() -> Result<(), Error> {
     let limit = 4;
-
-    let limiter = memory_limiter(limit, LONG_PERIOD);
-    let cloned_limiter = limiter.clone();
-
-    assert_eq!(limiter.count("key").await?.remaining(), 3);
-    assert_eq!(cloned_limiter.count("key").await?.remaining(), 2);
-    assert_eq!(limiter.count("key").await?.remaining(), 1);
-
     let store = MemoryStore::new();
     let first = Limiter::memory_builder(store.clone())
         .limit(limit)
@@ -141,83 +78,6 @@ async fn test_clones_share_counters() -> Result<(), Error> {
 
     assert_eq!(first.count("shared").await?.remaining(), 3);
     assert_eq!(second.count("shared").await?.remaining(), 2);
-
-    Ok(())
-}
-
-#[actix_web::test]
-async fn test_window_resets_after_period() -> Result<(), Error> {
-    let limit = 5;
-    let limiter = memory_limiter(limit, SHORT_PERIOD);
-
-    assert_eq!(limiter.count("key").await?.remaining(), limit - 1);
-    assert_eq!(limiter.count("key").await?.remaining(), limit - 2);
-
-    sleep(SHORT_PERIOD_PLUS);
-
-    assert_eq!(
-        limiter.count("key").await?.remaining(),
-        limit - 1,
-        "counter did not reset after the window elapsed",
-    );
-
-    Ok(())
-}
-
-#[actix_web::test]
-async fn test_window_does_not_slide() -> Result<(), Error> {
-    let gap = Duration::from_secs(3);
-    let limit = 10;
-    let limiter = memory_limiter(limit, LONG_PERIOD);
-
-    let first = limiter.count("key").await?;
-
-    sleep(gap);
-
-    let second = limiter.count("key").await?;
-
-    assert_eq!(
-        second.remaining(),
-        first.remaining() - 1,
-        "expected the second request to land in the first request's window",
-    );
-
-    assert!(
-        second.reset_epoch_utc() <= first.reset_epoch_utc() + 1,
-        "window slid: reset moved from {} to {} after a {:?} gap",
-        first.reset_epoch_utc(),
-        second.reset_epoch_utc(),
-        gap,
-    );
-
-    Ok(())
-}
-
-#[actix_web::test]
-async fn test_max_keys_fails_open() -> Result<(), Error> {
-    let limiter = Limiter::memory_builder(
-        MemoryStore::builder()
-            .max_keys(1)
-            .sweep_interval(LONG_PERIOD)
-            .build(),
-    )
-    .limit(1)
-    .period(LONG_PERIOD)
-    .build()
-    .unwrap();
-
-    assert_eq!(limiter.count("tracked").await?.remaining(), 0);
-    assert!(matches!(
-        limiter.count("tracked").await.unwrap_err(),
-        Error::LimitExceeded(_),
-    ));
-
-    for key in ["overflow-a", "overflow-b"] {
-        for _ in 0..5 {
-            let status = limiter.count(key).await?;
-            assert_eq!(status.remaining(), 0, "limit is 1, so one unit is consumed");
-        }
-    }
 
     Ok(())
 }

--- a/actix-limitation/tests/redis.rs
+++ b/actix-limitation/tests/redis.rs
@@ -4,7 +4,7 @@ use actix_limitation::{Error, Limiter, RateLimiter};
 use actix_web::{dev::ServiceRequest, http::StatusCode, test, web, App, HttpRequest, HttpResponse};
 use uuid::Uuid;
 
-#[test]
+#[actix_web::test]
 #[should_panic = "Redis URL did not parse"]
 async fn test_create_limiter_error() {
     Limiter::builder("127.0.0.1").build().unwrap();


### PR DESCRIPTION
## PR Type

  Feature

  ## PR Checklist

  - [x] Tests for the changes have been added / updated.
  - [x] Documentation comments have been added / updated.
  - [x] A changelog entry has been made for the appropriate packages.
  - [x] Format code with the nightly rustfmt (`cargo +nightly fmt`).

  ## Overview

  `actix-limitation` currently hard-wires Redis: `Limiter` owns a `redis::Client`, `Builder` holds a
  `redis_url: String`, and there is no way to rate limit without a running server. That cost shows up
  in this repo — `actix-limitation` is excluded from the macOS and Windows CI jobs entirely, because
  its tests need a Redis service container.

  This adds an opt-in `memory-store` feature providing a process-local fixed-window counter with the
  same semantics as the Redis path, so local development, examples and tests need no Redis.

  **This is fully non-breaking.** `redis` stays a required dependency and the default, unchanged path.
  No existing public API is removed, gated, or altered.

  ### New public API

  ```rust
  // off-by-default `memory-store` feature
  Limiter::memory_builder(MemoryStore::new())                              // defaults
  Limiter::memory_builder(MemoryStore::builder().max_keys(10_000).build()) // bounded
  ```

  `MemoryStore` is `Clone + Default + Debug`; clones share one set of counters. Counters expire on a
  lazy sweep that runs on a write at most once a minute — there is no background task. The map is
  unbounded by default; with `max_keys` set the store **fails open** once full (new keys pass
  untracked, with a rate-limited warning) rather than evicting counters out from under clients already
  being tracked.

  Constructing a store logs one `WARN` at startup, so an in-memory store shipped to production by
  accident is visible in the logs without per-request noise.

  ### Internal refactor

  `Limiter::track`'s Redis pipeline moved into `src/store/redis.rs`, unchanged apart from dropping
  trailing comments that restated the Redis command next to them. `Limiter` now holds a private
  `backend: Backend` enum and `track` is a two-arm dispatch. `Builder` holds a private `BackendSpec`,
  so `Client::open` still happens in `build()` and a malformed URL is still an `Err` there.

  ### Notes for review

  Three decisions worth flagging up front, since each was made against a real alternative:

  - **Private enum, no public `Store` trait.** Keeps `Limiter` non-generic, so the middleware's
    type-erased `app_data::<web::Data<Limiter>>()` lookup is untouched. Third parties can't add
    backends; that seemed the right trade for not changing the middleware's shape.

  - **The two backends are deliberately co-compilable — no `compile_error!` on the combination.**
    Using two backends on one `Limiter` is already unrepresentable (one enum variant, one constructor
    each, no `Builder` method to swap it), so an exclusion would guard nothing. It would, however,
    break `[package.metadata.docs.rs] all-features = true`, force `actix-limitation` onto the
    `--all-features` exclusion lists alongside `tracing-actix-web` and `actix-settings`, and — worst —
    make downstream graphs unbuildable through feature unification when two unrelated crates each pick
    a different backend. The reasoning is recorded in the `MemoryStore` rustdoc so it isn't later
    mistaken for an oversight.

  - **`redis` stays a required dependency.** Gating it behind a default-on `redis-store` feature would
    slim memory-only builds, but it is breaking for `default-features = false` consumers and
    additionally requires cfg-gating `Error::Client`, the middleware match arm and the
    `static_assertions` block. Happy to do it as a follow-up on its own major bump if you'd prefer
    that direction — say the word and I'll fold it in here instead.

  ### Tests, CI and docs

  - `tests/memory.rs` — 6 integration tests, **no external service**: counting,
    `Error::LimitExceeded`, two limiters sharing one store, and three end-to-end middleware runs
    through `test::init_service` (limiting, unkeyed passthrough, window reset). The store's own
    semantics — fixed non-sliding window, key independence, sweep eviction, fail-open at `max_keys` —
    are unit tested in `src/store/memory.rs`.

  - `.github/workflows/ci.yml` — `build_and_test_other` gains a step running just those tests:

    ```yaml
    - name: tests (actix-limitation, memory store)
      timeout-minutes: 10
      run: cargo test -p actix-limitation --features memory-store --test memory
    ```

    This is the crate's first cross-platform test coverage; the Redis exclusion stays as-is.

  - `tests/tests.rs` → `tests/redis.rs`, to name what it actually needs. Its one bare `#[test]` on an
    `async fn` is now an explicit `#[actix_web::test]` — behaviour is unchanged (the bare attribute
    was already resolving to `actix_web::test` via the `use` on line 4), but the implicit shadowing is
    easy to misread and would break confusingly if `test` were dropped from that import.

  - Two examples: `memory` (runs with nothing installed) and `redis` (same app, one line different at
    the builder). Only `memory` gets an `[[example]]` stanza, since only it has `required-features`.

  - The self-referencing dev-dependency follows the pattern at `actix-session/Cargo.toml:44`, so the
    integration tests need no `#[cfg]` juggling:

    ```toml
    [dev-dependencies]
    actix-limitation = { path = ".", features = ["memory-store"] }
    ```

  - Drive-by doc fix: `Builder::build`'s comment claimed it "will connect to the Redis server to test
    its connection which is a **synchronous** operation". It doesn't — `Client::open` only parses the
    URL.

  - README gains a Backends section, and the stale `actix-limitation = "0.5"` snippet is corrected to
    `0.6`. The crate `description` and `keywords` now mention the in-memory backend.

  ### Verification

  ```sh
  cargo check -p actix-limitation                                        # default, unchanged
  cargo hack check -p actix-limitation --no-default-features
  cargo check -p actix-limitation --features memory-store
  cargo check -p actix-limitation --all-features
  cargo hack check -p actix-limitation --no-default-features --examples
  cargo check -p actix-limitation --all-features --examples
  cargo test  -p actix-limitation --all-features                         # 21 + 6 + 4 + 4 doctests
  cargo test  -p actix-limitation --features memory-store --test memory  # passes with Redis stopped
  just doc && just clippy && cargo +nightly fmt --all -- --check
  ```

  Also confirmed by hand with Redis stopped:

  ```console
  $ RUST_LOG=warn cargo run --example memory --features memory-store
  $ for i in $(seq 6); do curl -s -o /dev/null -w "%{http_code} " localhost:8080; done
  200 200 200 200 200 429
  ```

  The process-local warning fires exactly once at startup.